### PR TITLE
Feat/iris soft hook toggle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,11 +12,10 @@ plugins {
 version = "${property("mod.version")}+${sc.current.version}"
 base.archivesName = property("mod.id") as String
 
-val requiredJava = when {
-    sc.current.parsed >= "1.20.6" -> JavaVersion.VERSION_21
-    sc.current.parsed >= "1.18" -> JavaVersion.VERSION_17
-    sc.current.parsed >= "1.17" -> JavaVersion.VERSION_16
-    else -> JavaVersion.VERSION_1_8
+val requiredJava = JavaVersion.VERSION_21
+
+if (JavaVersion.current() < requiredJava) {
+    throw GradleException("Nebula requires JDK 21 or later. Current JVM: ${JavaVersion.current()}")
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=false
 
 # Mod properties
-mod.version=1.0.8
+mod.version=1.1.0
 mod.group=com.atemukesu
 mod.id=nebula
 mod.name=Nebula

--- a/src/main/java/com/atemukesu/nebula/client/ClientAnimationManager.java
+++ b/src/main/java/com/atemukesu/nebula/client/ClientAnimationManager.java
@@ -39,6 +39,7 @@
 package com.atemukesu.nebula.client;
 
 import com.atemukesu.nebula.client.enums.BlendMode;
+import com.atemukesu.nebula.client.bridge.IrisBridge;
 import com.atemukesu.nebula.client.enums.CullingBehavior;
 import com.atemukesu.nebula.client.enums.RenderPipeline;
 import com.atemukesu.nebula.client.gui.tools.PerformanceStats;
@@ -259,18 +260,24 @@ public class ClientAnimationManager {
 
         // Global OIT Setup or Standard Batch Setup
         boolean isOIT = config.getBlendMode() == BlendMode.OIT;
+        boolean useExternalProgram = IrisUtil.isIrisRenderingActive();
         CullingBehavior behavior = config.getCullingBehavior();
         double now = CurrentTimeUtil.getCurrentAnimationTime();
         int targetFboId = -1;
+        boolean irisParticlePhaseActive = false;
+        try {
         if (!renderList.isEmpty()) {
+            if (useExternalProgram) {
+                irisParticlePhaseActive = IrisBridge.getInstance().beginParticlePhase();
+            }
             if (isOIT) {
                 targetFboId = GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING);
                 GpuParticleRenderer.beginOIT(targetFboId, client.getWindow().getFramebufferWidth(),
-                        client.getWindow().getFramebufferHeight());
+                        client.getWindow().getFramebufferHeight(), useExternalProgram);
             } else {
                 int currentFbo = GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING);
                 GpuParticleRenderer.beginStandardRendering(mvMatrix, projectionMatrix,
-                        currentFbo);
+                        currentFbo, useExternalProgram);
             }
         }
 
@@ -371,11 +378,16 @@ public class ClientAnimationManager {
             stats.endFrame();
         }
 
-        if (!renderList.isEmpty()) {
-            if (isOIT) {
-                GpuParticleRenderer.endOITAndComposite(targetFboId);
-            } else {
-                GpuParticleRenderer.endStandardRendering();
+            if (!renderList.isEmpty()) {
+                if (isOIT) {
+                    GpuParticleRenderer.endOITAndComposite(targetFboId);
+                } else {
+                    GpuParticleRenderer.endStandardRendering();
+                }
+            }
+        } finally {
+            if (irisParticlePhaseActive) {
+                IrisBridge.getInstance().endParticlePhase();
             }
         }
     }
@@ -600,6 +612,16 @@ public class ClientAnimationManager {
             stats.setEmissiveStrength(effectiveEmissive);
             stats.endFrame();
         }
+    }
+
+    public void renderTickFromParticlePhase(Camera camera, float tickDelta) {
+        if (!IrisUtil.isIrisRenderingActive()) {
+            return;
+        }
+        Matrix4f modelViewMatrix = new Matrix4f();
+        modelViewMatrix.rotate(camera.getRotation().conjugate(new Quaternionf()));
+        Matrix4f projectionMatrix = RenderSystem.getProjectionMatrix();
+        renderTickMixin(modelViewMatrix, projectionMatrix, camera, null, false);
     }
 
     public void updateParticlePositions(Camera camera, Frustum frustum, float tickDelta) {

--- a/src/main/java/com/atemukesu/nebula/client/ClientAnimationManager.java
+++ b/src/main/java/com/atemukesu/nebula/client/ClientAnimationManager.java
@@ -219,10 +219,10 @@ public class ClientAnimationManager {
 
         // 记录日志
         if (bindFramebuffer && !hasLoggedStandardRenderPath) {
-            Nebula.LOGGER.info("[Nebula/Render] ✓ Rendering via Mixin (standard mode).");
+            Nebula.LOGGER.info("[Nebula/Render] Rendering via Mixin (standard mode).");
             hasLoggedStandardRenderPath = true;
         } else if (!bindFramebuffer && !hasLoggedIrisRenderPath) {
-            Nebula.LOGGER.info("[Nebula/Render] ✓ Rendering via Mixin (Iris mode).");
+            Nebula.LOGGER.info("[Nebula/Render] Rendering via Mixin (Iris mode).");
             hasLoggedIrisRenderPath = true;
         }
 
@@ -259,7 +259,7 @@ public class ClientAnimationManager {
         }
 
         // Global OIT Setup or Standard Batch Setup
-        boolean isOIT = config.getBlendMode() == BlendMode.OIT;
+        boolean isOIT = config.getEffectiveBlendMode() == BlendMode.OIT;
         boolean useExternalProgram = IrisUtil.isIrisRenderingActive();
         CullingBehavior behavior = config.getCullingBehavior();
         double now = CurrentTimeUtil.getCurrentAnimationTime();
@@ -436,7 +436,7 @@ public class ClientAnimationManager {
 
         // 记录标准渲染路径日志（只记录一次）
         if (!hasLoggedStandardRenderPath) {
-            Nebula.LOGGER.info("[Nebula/Render] ✓ Using standard render path (WorldRenderEvents.LAST).");
+            Nebula.LOGGER.info("[Nebula/Render] Using standard render path (WorldRenderEvents.LAST).");
             hasLoggedStandardRenderPath = true;
         }
 
@@ -483,7 +483,7 @@ public class ClientAnimationManager {
         }
 
         // Global OIT Setup or Standard Batch Setup
-        boolean isOIT = config.getBlendMode() == BlendMode.OIT;
+        boolean isOIT = config.getEffectiveBlendMode() == BlendMode.OIT;
         CullingBehavior behavior = config.getCullingBehavior();
         double now = CurrentTimeUtil.getCurrentAnimationTime();
         int targetFboId = -1;

--- a/src/main/java/com/atemukesu/nebula/client/NebulaClient.java
+++ b/src/main/java/com/atemukesu/nebula/client/NebulaClient.java
@@ -249,7 +249,7 @@ public class NebulaClient implements ClientModInitializer {
         //? }
 
         ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
-            if (ModConfig.getInstance().getBlendMode() == BlendMode.OIT) {
+            if (ModConfig.getInstance().getEffectiveBlendMode() == BlendMode.OIT) {
                 int w = client.getWindow().getFramebufferWidth();
                 int h = client.getWindow().getFramebufferHeight();
                 GpuParticleRenderer.preloadOIT(w, h);

--- a/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
+++ b/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
@@ -42,6 +42,7 @@ import com.atemukesu.nebula.Nebula;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.loader.api.FabricLoader;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL20;
 import org.lwjgl.opengl.GL30;
 
 import java.lang.reflect.Field;
@@ -62,12 +63,32 @@ public class IrisBridge {
     private Method getSodiumPipelineMethod; // getSodiumTerrainPipeline
     private Method getTranslucentFbMethod; // getTranslucentFramebuffer
     private Method bindFbMethod; // GlFramebuffer.bind
+    private Method pipelineSetPhaseMethod;
+    private Class<?> pipelineSetPhaseOwner;
+    private Class<?> worldRenderingPhaseClass;
+    private Object particlesPhase;
+    private Object nonePhase;
 
     // Reflection handles (Util usage)
     private Class<?> irisInternalClass;
     private Method getPipelineManagerMethod;
     private Object irisApiInstance;
     private Method isShaderPackInUseMethod;
+    private Method getParticleTranslucentShaderMethod;
+    private Method getShaderMapMethod;
+    private Method getShaderMethod;
+    private Object particleOpaqueShaderKey;
+    private Object activeParticleShader;
+    private final Map<Class<?>, Method> shaderBindMethodCache = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Method> shaderUnbindMethodCache = new ConcurrentHashMap<>();
+    private boolean loggedSodiumFramebufferBinding = false;
+    private boolean loggedGenericFramebufferBinding = false;
+    private boolean loggedFramebufferBindingFailure = false;
+    private boolean loggedParticleShaderBinding = false;
+    private boolean loggedParticleShaderNoProgram = false;
+    private boolean loggedParticleShaderBindingFailure = false;
+    private boolean loggedParticlePhaseBinding = false;
+    private boolean loggedParticlePhaseFailure = false;
 
     // Caches (Util usage)
     private final Map<Class<?>, Field> fboFieldCache = new ConcurrentHashMap<>();
@@ -114,6 +135,19 @@ public class IrisBridge {
             irisApiInstance = getIrisApiMethod.invoke(null);
             isShaderPackInUseMethod = irisApiClass.getMethod("isShaderPackInUse");
 
+            Class<?> shaderAccessClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderAccess");
+            getParticleTranslucentShaderMethod = shaderAccessClass.getMethod("getParticleTranslucentShader");
+
+            // ShaderAccess only exposes PARTICLES_TRANS.  Resolve PARTICLES through
+            // the public pipeline shader map so opaque and translucent particles do
+            // not get forced into the same Iris render target.
+            Class<?> shaderRenderingPipelineClass = Class.forName("net.irisshaders.iris.pipeline.ShaderRenderingPipeline");
+            Class<?> shaderKeyClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderKey");
+            Class<?> shaderMapClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderMap");
+            getShaderMapMethod = shaderRenderingPipelineClass.getMethod("getShaderMap");
+            getShaderMethod = shaderMapClass.getMethod("getShader", shaderKeyClass);
+            particleOpaqueShaderKey = shaderKeyClass.getField("PARTICLES").get(null);
+
             // Common: Iris.getPipelineManager()
             irisInternalClass = Class.forName("net.irisshaders.iris.Iris");
             getPipelineManagerMethod = irisInternalClass.getMethod("getPipelineManager");
@@ -123,6 +157,12 @@ public class IrisBridge {
                 Class<?> managerClass = irisPipelineManager.getClass();
                 getPipelineMethod = managerClass.getMethod("getPipelineNullable");
             }
+
+            worldRenderingPhaseClass = Class.forName("net.irisshaders.iris.pipeline.WorldRenderingPhase");
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            Class phaseEnumClass = worldRenderingPhaseClass.asSubclass(Enum.class);
+            particlesPhase = Enum.valueOf(phaseEnumClass, "PARTICLES");
+            nonePhase = Enum.valueOf(phaseEnumClass, "NONE");
 
             // Mixin specific targets
             try {
@@ -155,9 +195,163 @@ public class IrisBridge {
 
     public boolean bindTranslucentFramebuffer() {
         if (attemptBindSodiumTranslucentFramebuffer()) {
+            if (!loggedSodiumFramebufferBinding) {
+                Nebula.LOGGER.info("[Nebula/IrisBridge] Bound Iris translucent framebuffer via Sodium pipeline.");
+                loggedSodiumFramebufferBinding = true;
+            }
             return true;
         }
-        return bindIrisTranslucentFramebufferGeneric();
+        boolean bound = bindIrisTranslucentFramebufferGeneric();
+        if (bound) {
+            if (!loggedGenericFramebufferBinding) {
+                Nebula.LOGGER.info("[Nebula/IrisBridge] Bound Iris translucent framebuffer via generic reflection path.");
+                loggedGenericFramebufferBinding = true;
+            }
+        } else if (!loggedFramebufferBindingFailure) {
+            Nebula.LOGGER.warn("[Nebula/IrisBridge] Failed to bind a dedicated Iris translucent framebuffer; falling back to current framebuffer.");
+            loggedFramebufferBindingFailure = true;
+        }
+        return bound;
+    }
+
+    public boolean bindParticleTranslucentShader() {
+        return bindParticleShader(true) > 0;
+    }
+
+    /**
+     * Binds Iris' real opaque/translucent particle program and returns its GL id.
+     */
+    public int bindParticleShader(boolean translucent) {
+        if (!available) {
+            return 0;
+        }
+        initReflection();
+        if (getParticleTranslucentShaderMethod == null || getPipelineMethod == null) {
+            return 0;
+        }
+
+        try {
+            Object shader;
+            if (translucent) {
+                shader = getParticleTranslucentShaderMethod.invoke(null);
+            } else {
+                Object pipeline = getPipelineMethod.invoke(irisPipelineManager);
+                if (pipeline == null || getShaderMapMethod == null || getShaderMethod == null || particleOpaqueShaderKey == null) {
+                    return 0;
+                }
+                Object shaderMap = getShaderMapMethod.invoke(pipeline);
+                shader = getShaderMethod.invoke(shaderMap, particleOpaqueShaderKey);
+            }
+            if (shader == null) {
+                return 0;
+            }
+            Method bindMethod = shaderBindMethodCache.computeIfAbsent(
+                    shader.getClass(),
+                    clazz -> findNoArgMethod(clazz, "bind", "method_34586"));
+            if (bindMethod == null) {
+                return 0;
+            }
+            bindMethod.invoke(shader);
+            int activeProgram = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+            if (activeProgram <= 0) {
+                activeParticleShader = null;
+                if (!loggedParticleShaderNoProgram) {
+                    Nebula.LOGGER.warn("[Nebula/IrisBridge] Iris particle shader bind completed without an active GL program.");
+                    loggedParticleShaderNoProgram = true;
+                }
+                return 0;
+            }
+            activeParticleShader = shader;
+            if (!loggedParticleShaderBinding) {
+                Nebula.LOGGER.info("[Nebula/IrisBridge] Bound Iris particle translucent shader: {}", shader.getClass().getName());
+                loggedParticleShaderBinding = true;
+            }
+            return activeProgram;
+        } catch (Exception e) {
+            if (!loggedParticleShaderBindingFailure) {
+                Nebula.LOGGER.warn("[Nebula/IrisBridge] Failed to bind Iris particle translucent shader: {}", e.toString());
+                loggedParticleShaderBindingFailure = true;
+            }
+            return 0;
+        }
+    }
+
+    public boolean beginParticlePhase() {
+        boolean phaseSet = setWorldRenderingPhase(particlesPhase);
+        boolean shaderBound = bindParticleTranslucentShader();
+        if (phaseSet && shaderBound && !loggedParticlePhaseBinding) {
+            Nebula.LOGGER.info("[Nebula/IrisBridge] Entered Iris PARTICLES phase and bound particles_trans shader.");
+            loggedParticlePhaseBinding = true;
+        }
+        return phaseSet || shaderBound;
+    }
+
+    public void endParticlePhase() {
+        unbindParticleTranslucentShader();
+        setWorldRenderingPhase(nonePhase);
+    }
+
+    private boolean setWorldRenderingPhase(Object phase) {
+        if (!available || phase == null) {
+            return false;
+        }
+        initReflection();
+        if (irisPipelineManager == null || getPipelineMethod == null || worldRenderingPhaseClass == null) {
+            return false;
+        }
+        try {
+            Object pipeline = getPipelineMethod.invoke(irisPipelineManager);
+            if (pipeline == null) {
+                return false;
+            }
+            if (pipelineSetPhaseMethod == null || pipelineSetPhaseOwner != pipeline.getClass()) {
+                pipelineSetPhaseMethod = pipeline.getClass().getMethod("setPhase", worldRenderingPhaseClass);
+                pipelineSetPhaseMethod.setAccessible(true);
+                pipelineSetPhaseOwner = pipeline.getClass();
+            }
+            pipelineSetPhaseMethod.invoke(pipeline, phase);
+            return true;
+        } catch (Exception e) {
+            if (!loggedParticlePhaseFailure) {
+                Nebula.LOGGER.warn("[Nebula/IrisBridge] Failed to set Iris particle phase: {}", e.toString());
+                loggedParticlePhaseFailure = true;
+            }
+            return false;
+        }
+    }
+
+    public void unbindParticleTranslucentShader() {
+        Object shader = activeParticleShader;
+        activeParticleShader = null;
+        if (shader == null) {
+            return;
+        }
+        try {
+            Method unbindMethod = shaderUnbindMethodCache.computeIfAbsent(
+                    shader.getClass(),
+                    clazz -> findNoArgMethod(clazz, "unbind", "method_34585"));
+            if (unbindMethod != null) {
+                unbindMethod.invoke(shader);
+            }
+        } catch (Exception e) {
+            Nebula.LOGGER.debug("[Nebula/IrisBridge] Failed to unbind Iris particle shader: {}", e.toString());
+        }
+    }
+
+    private Method findNoArgMethod(Class<?> type, String... names) {
+        Class<?> current = type;
+        while (current != null) {
+            for (String name : names) {
+                try {
+                    Method method = current.getDeclaredMethod(name);
+                    method.setAccessible(true);
+                    return method;
+                } catch (NoSuchMethodException ignored) {
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
+++ b/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
@@ -40,6 +40,7 @@ package com.atemukesu.nebula.client.bridge;
 
 import com.atemukesu.nebula.Nebula;
 import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.MinecraftClient;
 import net.fabricmc.loader.api.FabricLoader;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
@@ -68,6 +69,7 @@ public class IrisBridge {
     private Class<?> worldRenderingPhaseClass;
     private Object particlesPhase;
     private Object nonePhase;
+    private int particlePhaseRestoreFbo = -1;
 
     // Reflection handles (Util usage)
     private Class<?> irisInternalClass;
@@ -78,6 +80,7 @@ public class IrisBridge {
     private Method getShaderMapMethod;
     private Method getShaderMethod;
     private Object particleOpaqueShaderKey;
+    private Object particleTranslucentShaderKey;
     private Object activeParticleShader;
     private final Map<Class<?>, Method> shaderBindMethodCache = new ConcurrentHashMap<>();
     private final Map<Class<?>, Method> shaderUnbindMethodCache = new ConcurrentHashMap<>();
@@ -135,18 +138,26 @@ public class IrisBridge {
             irisApiInstance = getIrisApiMethod.invoke(null);
             isShaderPackInUseMethod = irisApiClass.getMethod("isShaderPackInUse");
 
-            Class<?> shaderAccessClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderAccess");
-            getParticleTranslucentShaderMethod = shaderAccessClass.getMethod("getParticleTranslucentShader");
-
-            // ShaderAccess only exposes PARTICLES_TRANS.  Resolve PARTICLES through
-            // the public pipeline shader map so opaque and translucent particles do
-            // not get forced into the same Iris render target.
-            Class<?> shaderRenderingPipelineClass = Class.forName("net.irisshaders.iris.pipeline.ShaderRenderingPipeline");
-            Class<?> shaderKeyClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderKey");
-            Class<?> shaderMapClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderMap");
-            getShaderMapMethod = shaderRenderingPipelineClass.getMethod("getShaderMap");
-            getShaderMethod = shaderMapClass.getMethod("getShader", shaderKeyClass);
-            particleOpaqueShaderKey = shaderKeyClass.getField("PARTICLES").get(null);
+            // Iris changed ShaderAccess between releases.  Neither optional lookup
+            // is allowed to disable the complete bridge: the shader map is a
+            // compatible fallback for both PARTICLES and PARTICLES_TRANS.
+            try {
+                Class<?> shaderAccessClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderAccess");
+                getParticleTranslucentShaderMethod = shaderAccessClass.getMethod("getParticleTranslucentShader");
+            } catch (ReflectiveOperationException ignored) {
+                Nebula.LOGGER.debug("[Nebula/IrisBridge] ShaderAccess particle lookup is unavailable; using ShaderMap.");
+            }
+            try {
+                Class<?> shaderRenderingPipelineClass = Class.forName("net.irisshaders.iris.pipeline.ShaderRenderingPipeline");
+                Class<?> shaderKeyClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderKey");
+                Class<?> shaderMapClass = Class.forName("net.irisshaders.iris.pipeline.programs.ShaderMap");
+                getShaderMapMethod = shaderRenderingPipelineClass.getMethod("getShaderMap");
+                getShaderMethod = shaderMapClass.getMethod("getShader", shaderKeyClass);
+                particleOpaqueShaderKey = shaderKeyClass.getField("PARTICLES").get(null);
+                particleTranslucentShaderKey = shaderKeyClass.getField("PARTICLES_TRANS").get(null);
+            } catch (ReflectiveOperationException ignored) {
+                Nebula.LOGGER.debug("[Nebula/IrisBridge] ShaderMap particle lookup is unavailable.");
+            }
 
             // Common: Iris.getPipelineManager()
             irisInternalClass = Class.forName("net.irisshaders.iris.Iris");
@@ -226,21 +237,22 @@ public class IrisBridge {
             return 0;
         }
         initReflection();
-        if (getParticleTranslucentShaderMethod == null || getPipelineMethod == null) {
+        if (getPipelineMethod == null) {
             return 0;
         }
 
         try {
             Object shader;
-            if (translucent) {
+            if (translucent && getParticleTranslucentShaderMethod != null) {
                 shader = getParticleTranslucentShaderMethod.invoke(null);
             } else {
                 Object pipeline = getPipelineMethod.invoke(irisPipelineManager);
-                if (pipeline == null || getShaderMapMethod == null || getShaderMethod == null || particleOpaqueShaderKey == null) {
+                Object shaderKey = translucent ? particleTranslucentShaderKey : particleOpaqueShaderKey;
+                if (pipeline == null || getShaderMapMethod == null || getShaderMethod == null || shaderKey == null) {
                     return 0;
                 }
                 Object shaderMap = getShaderMapMethod.invoke(pipeline);
-                shader = getShaderMethod.invoke(shaderMap, particleOpaqueShaderKey);
+                shader = getShaderMethod.invoke(shaderMap, shaderKey);
             }
             if (shader == null) {
                 return 0;
@@ -277,6 +289,12 @@ public class IrisBridge {
     }
 
     public boolean beginParticlePhase() {
+        // ExtendedShader.bind() selects an Iris framebuffer.  Keep the caller's
+        // target so a late particle draw (for example just before weather) does
+        // not leave subsequent vanilla/Iris passes bound to the particle target.
+        if (particlePhaseRestoreFbo < 0) {
+            particlePhaseRestoreFbo = GL11.glGetInteger(GL30.GL_DRAW_FRAMEBUFFER_BINDING);
+        }
         boolean phaseSet = setWorldRenderingPhase(particlesPhase);
         boolean shaderBound = bindParticleTranslucentShader();
         if (phaseSet && shaderBound && !loggedParticlePhaseBinding) {
@@ -289,6 +307,16 @@ public class IrisBridge {
     public void endParticlePhase() {
         unbindParticleTranslucentShader();
         setWorldRenderingPhase(nonePhase);
+        int restoreFbo = particlePhaseRestoreFbo;
+        particlePhaseRestoreFbo = -1;
+        if (restoreFbo >= 0) {
+            MinecraftClient client = MinecraftClient.getInstance();
+            if (client.getFramebuffer() != null && restoreFbo == client.getFramebuffer().fbo) {
+                client.getFramebuffer().beginWrite(false);
+            } else {
+                GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, restoreFbo);
+            }
+        }
     }
 
     private boolean setWorldRenderingPhase(Object phase) {

--- a/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
+++ b/src/main/java/com/atemukesu/nebula/client/bridge/IrisBridge.java
@@ -41,7 +41,6 @@ package com.atemukesu.nebula.client.bridge;
 import com.atemukesu.nebula.Nebula;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.loader.api.FabricLoader;
-import net.irisshaders.iris.api.v0.IrisApi;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
@@ -67,6 +66,8 @@ public class IrisBridge {
     // Reflection handles (Util usage)
     private Class<?> irisInternalClass;
     private Method getPipelineManagerMethod;
+    private Object irisApiInstance;
+    private Method isShaderPackInUseMethod;
 
     // Caches (Util usage)
     private final Map<Class<?>, Field> fboFieldCache = new ConcurrentHashMap<>();
@@ -88,8 +89,12 @@ public class IrisBridge {
     public boolean isIrisRenderingActive() {
         if (!isIrisInstalled())
             return false;
+        initReflection();
+        if (irisApiInstance == null || isShaderPackInUseMethod == null) {
+            return false;
+        }
         try {
-            return IrisApi.getInstance().isShaderPackInUse();
+            return (boolean) isShaderPackInUseMethod.invoke(irisApiInstance);
         } catch (Throwable t) {
             return false;
         }
@@ -104,6 +109,11 @@ public class IrisBridge {
             return;
 
         try {
+            Class<?> irisApiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            Method getIrisApiMethod = irisApiClass.getMethod("getInstance");
+            irisApiInstance = getIrisApiMethod.invoke(null);
+            isShaderPackInUseMethod = irisApiClass.getMethod("isShaderPackInUse");
+
             // Common: Iris.getPipelineManager()
             irisInternalClass = Class.forName("net.irisshaders.iris.Iris");
             getPipelineManagerMethod = irisInternalClass.getMethod("getPipelineManager");

--- a/src/main/java/com/atemukesu/nebula/client/config/ModConfig.java
+++ b/src/main/java/com/atemukesu/nebula/client/config/ModConfig.java
@@ -42,6 +42,7 @@ import com.atemukesu.nebula.client.enums.BlendMode;
 import com.atemukesu.nebula.client.enums.CullingBehavior;
 import com.atemukesu.nebula.client.enums.RenderPipeline;
 import com.atemukesu.nebula.client.render.GpuParticleRenderer;
+import com.atemukesu.nebula.client.util.IrisUtil;
 
 import net.minecraft.client.MinecraftClient;
 
@@ -132,13 +133,26 @@ public class ModConfig {
     }
 
     /**
+     * Shaderpack framebuffers cannot use Nebula's Alpha/Additive/OIT paths
+     * safely.  Iris therefore uses the dedicated depth-priority path instead;
+     * the configured blend mode is preserved for non-Iris rendering.
+     */
+    public boolean isIrisDepthPriority() {
+        return getRenderPipeline() == RenderPipeline.GPU && IrisUtil.isIrisRenderingActive();
+    }
+
+    public BlendMode getEffectiveBlendMode() {
+        return isIrisDepthPriority() ? BlendMode.ALPHA : getBlendMode();
+    }
+
+    /**
      * 设置粒子混合模式
      */
     public void setBlendMode(BlendMode blendMode) {
         this.blendMode = blendMode;
         // 预加载 OIT
         MinecraftClient client = MinecraftClient.getInstance();
-        if (this.blendMode == BlendMode.OIT && client.getWindow() != null) {
+        if (this.blendMode == BlendMode.OIT && !isIrisDepthPriority() && client.getWindow() != null) {
             int w = client.getWindow().getFramebufferWidth();
             int h = client.getWindow().getFramebufferHeight();
             if (w > 0 && h > 0) {

--- a/src/main/java/com/atemukesu/nebula/client/config/ModConfig.java
+++ b/src/main/java/com/atemukesu/nebula/client/config/ModConfig.java
@@ -62,6 +62,9 @@ public class ModConfig {
     private float emissiveStrength;
     private CullingBehavior cullingBehavior;
     
+    // 调试选项
+    private boolean saveInjectedCode;
+    
     // 测试选项
     private boolean syncSingleplayerAnimations;
 
@@ -78,6 +81,8 @@ public class ModConfig {
         // 默认使用用户自定义的亮度
         this.emissiveStrength = 2.0f;
         this.cullingBehavior = CullingBehavior.SIMULATE_ONLY;
+        // 默认关闭保存注入后的着色器代码
+        this.saveInjectedCode = false;
         // 默认关闭单人模式动画同步（测试用）
         this.syncSingleplayerAnimations = false;
     }
@@ -208,6 +213,14 @@ public class ModConfig {
      */
     public void setCullingBehavior(CullingBehavior cullingBehavior) {
         this.cullingBehavior = cullingBehavior;
+    }
+
+    public boolean getSaveInjectedCode() {
+        return this.saveInjectedCode;
+    }
+
+    public void setSaveInjectedCode(Boolean saveInjectedCode) {
+        this.saveInjectedCode = saveInjectedCode;
     }
     
     /**

--- a/src/main/java/com/atemukesu/nebula/client/config/NebulaYACLConfig.java
+++ b/src/main/java/com/atemukesu/nebula/client/config/NebulaYACLConfig.java
@@ -108,6 +108,18 @@ public class NebulaYACLConfig {
                                                                                 config::setSyncSingleplayerAnimations)
                                                                 .controller(BooleanControllerBuilder::create)
                                                                 .build())
+                                                .option(Option.<Boolean>createBuilder()
+                                                                .name(Text.translatable(
+                                                                                "gui.nebula.config.save_injected_code"))
+                                                                .description(OptionDescription
+                                                                                .of(Text.translatable(
+                                                                                                "gui.nebula.config.save_injected_code.desc")))
+                                                                .binding(
+                                                                                false,
+                                                                                config::getSaveInjectedCode,
+                                                                                config::setSaveInjectedCode)
+                                                                .controller(BooleanControllerBuilder::create)
+                                                                .build())
                                                 .build())
                                 .category(ConfigCategory.createBuilder()
                                                 .name(Text.translatable("gui.nebula.config.category.rendering"))

--- a/src/main/java/com/atemukesu/nebula/client/config/NebulaYACLConfig.java
+++ b/src/main/java/com/atemukesu/nebula/client/config/NebulaYACLConfig.java
@@ -52,6 +52,7 @@ import net.minecraft.text.Text;
 public class NebulaYACLConfig {
         public static Screen createConfigScreen(Screen parent) {
                 ModConfig config = ModConfig.getInstance();
+                boolean irisDepthPriority = config.isIrisDepthPriority();
 
                 return YetAnotherConfigLib.createBuilder()
                                 .title(Text.translatable("gui.nebula.config.title"))
@@ -126,16 +127,19 @@ public class NebulaYACLConfig {
                                                                 .build())
                                                 .option(Option.<BlendMode>createBuilder()
                                                                 .name(Text.translatable("gui.nebula.config.blend_mode"))
-                                                                .description(OptionDescription.of(Text.translatable(
-                                                                                "gui.nebula.config.blend_mode.desc")))
+                                                                .description(OptionDescription.of(irisDepthPriority
+                                                                                ? Text.translatable("gui.nebula.config.blend_mode.depth_priority.desc")
+                                                                                : Text.translatable("gui.nebula.config.blend_mode.desc")))
                                                                 .binding(
                                                                                 BlendMode.ALPHA,
                                                                                 config::getBlendMode,
                                                                                 config::setBlendMode)
                                                                 .controller(opt -> EnumControllerBuilder.create(opt)
                                                                                 .enumClass(BlendMode.class)
-                                                                                .formatValue(mode -> Text.translatable(
-                                                                                                mode.getTranslationKey())))
+                                                                                .formatValue(mode -> irisDepthPriority
+                                                                                                ? Text.translatable("gui.nebula.config.blend_mode.depth_priority")
+                                                                                                : Text.translatable(mode.getTranslationKey())))
+                                                                .available(!irisDepthPriority)
                                                                 .build())
                                                 .option(Option.<CullingBehavior>createBuilder()
                                                                 .name(Text.translatable(

--- a/src/main/java/com/atemukesu/nebula/client/gui/DebugHud.java
+++ b/src/main/java/com/atemukesu/nebula/client/gui/DebugHud.java
@@ -47,6 +47,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.*;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
@@ -209,7 +210,9 @@ public class DebugHud {
                     0x55CCFF));
 
             // 显示当前混合模式
-            String blendModeStr = config.getBlendMode().name();
+            String blendModeStr = config.isIrisDepthPriority()
+                    ? Text.translatable("gui.nebula.config.blend_mode.depth_priority").getString()
+                    : config.getEffectiveBlendMode().name();
             String cullingBehaviorStr = config.getCullingBehavior().name();
             cachedLines.add(new CachedLine(
                     String.format("Blend: %s | Culling: %s", blendModeStr, cullingBehaviorStr),

--- a/src/main/java/com/atemukesu/nebula/client/mixin/MixinTransformPatcher.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/MixinTransformPatcher.java
@@ -1,12 +1,27 @@
 package com.atemukesu.nebula.client.mixin;
 
+import com.atemukesu.nebula.Nebula;
 import com.atemukesu.nebula.client.shader.IrisShaderTransformer;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(targets = "net.irisshaders.iris.pipeline.transform.TransformPatcher", remap = false)
 public class MixinTransformPatcher {
+
+    @Unique
+    private static final ThreadLocal<String> nebula$programName = new ThreadLocal<>();
+
+    @ModifyVariable(
+            method = "transform",
+            at = @At("HEAD"),
+            ordinal = 0,
+            argsOnly = true)
+    private static String nebula$captureProgramName(String programName) {
+        nebula$programName.set(programName);
+        return programName;
+    }
 
     @ModifyVariable(
             method = "transform",
@@ -14,6 +29,29 @@ public class MixinTransformPatcher {
             ordinal = 1,
             argsOnly = true)
     private static String nebula$transformVertexSource(String vertexSource) {
-        return IrisShaderTransformer.transformVertexSource(vertexSource);
+        String programName = nebula$programName.get();
+        String transformed = IrisShaderTransformer.transformVertexSource(programName, vertexSource);
+        if (transformed != vertexSource) {
+            Nebula.LOGGER.info("[Nebula/Iris] Injected Nebula vertex hook into {}.", programName);
+        }
+        return transformed;
+    }
+
+    @ModifyVariable(
+            method = "transform",
+            at = @At("HEAD"),
+            ordinal = 5,
+            argsOnly = true)
+    private static String nebula$transformFragmentSource(String fragmentSource) {
+        String programName = nebula$programName.get();
+        try {
+            String transformed = IrisShaderTransformer.transformFragmentSource(programName, fragmentSource);
+            if (transformed != fragmentSource) {
+                Nebula.LOGGER.info("[Nebula/Iris] Injected Nebula fragment hook into {}.", programName);
+            }
+            return transformed;
+        } finally {
+            nebula$programName.remove();
+        }
     }
 }

--- a/src/main/java/com/atemukesu/nebula/client/mixin/MixinTransformPatcher.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/MixinTransformPatcher.java
@@ -1,0 +1,19 @@
+package com.atemukesu.nebula.client.mixin;
+
+import com.atemukesu.nebula.client.shader.IrisShaderTransformer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(targets = "net.irisshaders.iris.pipeline.transform.TransformPatcher", remap = false)
+public class MixinTransformPatcher {
+
+    @ModifyVariable(
+            method = "transform",
+            at = @At("HEAD"),
+            ordinal = 1,
+            argsOnly = true)
+    private static String nebula$transformVertexSource(String vertexSource) {
+        return IrisShaderTransformer.transformVertexSource(vertexSource);
+    }
+}

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaMixinPlugin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaMixinPlugin.java
@@ -61,7 +61,7 @@ public class NebulaMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.endsWith("VideoRendererMixin")) {
             boolean replayModLoaded = FabricLoader.getInstance().isModLoaded("replaymod");
             if (replayModLoaded) {
-                Nebula.LOGGER.info("[Nebula/Mixin] ✓ Replay Mod detected. Applying mixin: {}", mixinClassName);
+                Nebula.LOGGER.info("[Nebula/Mixin] Replay Mod detected. Applying mixin: {}", mixinClassName);
             } else {
                 Nebula.LOGGER.debug("[Nebula/Mixin] Replay Mod not found. Skipping mixin: {}", mixinClassName);
             }
@@ -71,7 +71,7 @@ public class NebulaMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.endsWith("MixinTransformPatcher")) {
             boolean irisLoaded = FabricLoader.getInstance().isModLoaded("iris");
             if (irisLoaded) {
-                Nebula.LOGGER.info("[Nebula/Mixin] ✓ Iris detected. Applying mixin: {}", mixinClassName);
+                Nebula.LOGGER.info("[Nebula/Mixin] Iris detected. Applying mixin: {}", mixinClassName);
             } else {
                 Nebula.LOGGER.debug("[Nebula/Mixin] Iris not found. Skipping mixin: {}", mixinClassName);
             }

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaMixinPlugin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaMixinPlugin.java
@@ -24,7 +24,7 @@
  *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details <https://www.gnu.org/licenses/>.
+ * See the GNU General Public License for more details <https://www.gnu.org/licenses/>。
  *
  * 中文版：
  * 本程序为自由软件：您可以根据自由软件基金会发布的 GNU 通用公共许可协议（GPL）条款
@@ -38,30 +38,26 @@
 
 package com.atemukesu.nebula.client.mixin;
 
+import com.atemukesu.nebula.Nebula;
 import net.fabricmc.loader.api.FabricLoader;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
-
-import com.atemukesu.nebula.Nebula;
 
 import java.util.List;
 import java.util.Set;
 
 /**
  * Mixin 插件，用于实现对可选 Mod 的"软依赖"。
- * 
- * 核心作用是在应用 Mixin 之前进行检查，确保只在目标 Mod 存在时，
- * 针对它们的 Mixin 才会被应用，从而避免 ClassNotFoundException 导致游戏崩溃。
- * 
+ *
  * 当前支持的软依赖：
  * - Replay Mod: VideoRendererMixin
+ * - Iris: MixinTransformPatcher
  */
 public class NebulaMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
-        // === Replay Mod 软依赖 ===
         if (mixinClassName.endsWith("VideoRendererMixin")) {
             boolean replayModLoaded = FabricLoader.getInstance().isModLoaded("replaymod");
             if (replayModLoaded) {
@@ -72,7 +68,16 @@ public class NebulaMixinPlugin implements IMixinConfigPlugin {
             return replayModLoaded;
         }
 
-        // 对于所有其他的 Mixin，总是应用
+        if (mixinClassName.endsWith("MixinTransformPatcher")) {
+            boolean irisLoaded = FabricLoader.getInstance().isModLoaded("iris");
+            if (irisLoaded) {
+                Nebula.LOGGER.info("[Nebula/Mixin] ✓ Iris detected. Applying mixin: {}", mixinClassName);
+            } else {
+                Nebula.LOGGER.debug("[Nebula/Mixin] Iris not found. Skipping mixin: {}", mixinClassName);
+            }
+            return irisLoaded;
+        }
+
         return true;
     }
 

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaParticleManagerMixin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaParticleManagerMixin.java
@@ -1,0 +1,32 @@
+package com.atemukesu.nebula.client.mixin;
+
+import com.atemukesu.nebula.client.ClientAnimationManager;
+import net.minecraft.client.render.Camera;
+import net.minecraft.client.render.LightmapTextureManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.particle.ParticleManager")
+public class NebulaParticleManagerMixin {
+
+    @Inject(method = "renderParticles", at = @At("TAIL"))
+    private void nebula$renderAfterVanillaParticles(
+            //? if < 1.21 {
+            /*net.minecraft.client.util.math.MatrixStack matrices,
+            net.minecraft.client.render.VertexConsumerProvider.Immediate vertexConsumers,
+            LightmapTextureManager lightmapTextureManager,
+            Camera camera,
+            float tickDelta,
+            CallbackInfo ci
+            *///? } else {
+            LightmapTextureManager lightmapTextureManager,
+            Camera camera,
+            float tickDelta,
+            CallbackInfo ci
+            //? }
+    ) {
+        ClientAnimationManager.getInstance().renderTickFromParticlePhase(camera, tickDelta);
+    }
+}

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaParticleManagerMixin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaParticleManagerMixin.java
@@ -1,6 +1,8 @@
 package com.atemukesu.nebula.client.mixin;
 
 import com.atemukesu.nebula.client.ClientAnimationManager;
+import com.atemukesu.nebula.client.config.ModConfig;
+import com.atemukesu.nebula.client.enums.RenderPipeline;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.LightmapTextureManager;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,6 +29,9 @@ public class NebulaParticleManagerMixin {
             CallbackInfo ci
             //? }
     ) {
+        if (ModConfig.getInstance().getRenderPipeline() != RenderPipeline.VANILLA_BATCH) {
+            return;
+        }
         ClientAnimationManager.getInstance().renderTickFromParticlePhase(camera, tickDelta);
     }
 }

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
@@ -127,4 +127,43 @@ public class NebulaWorldRendererMixin {
                 return;
         }
 
+    /**
+     * In the fabulous/transparency-post-process path Minecraft renders particles
+     * before the translucent terrain pass.  GPU Nebula particles used to be
+     * injected at ParticleManager.TAIL, so low-alpha fragments (which correctly
+     * do not write depth) were overwritten by that later pass.  Render them just
+     * before weather instead: terrain translucency is complete, while Iris can
+     * still select its after-translucent particle framebuffer.
+     */
+    @Inject(method = "render", at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+            target = "Lnet/minecraft/client/render/WorldRenderer;renderWeather(Lnet/minecraft/client/render/LightmapTextureManager;FDDD)V"), require = 0)
+    private void nebula$renderIrisParticlesAfterTranslucency(
+            //? if < 1.21 {
+            /*MatrixStack matrices, float tickDelta, long limitTime,
+            boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer,
+            LightmapTextureManager lightmapTextureManager, Matrix4f projection,
+            CallbackInfo ci
+            *///? } else {
+            RenderTickCounter tickCounter, boolean renderBlockOutline, Camera camera, GameRenderer gameRenderer,
+            LightmapTextureManager lightmapTextureManager, Matrix4f positionMatrix, Matrix4f projectionMatrix,
+            CallbackInfo ci
+            //? }
+    ) {
+        if (ModConfig.getInstance().getRenderPipeline() != RenderPipeline.GPU
+                || !IrisBridge.getInstance().isIrisRenderingActive()) {
+            return;
+        }
+
+        if (!hasLoggedIrisPath) {
+            Nebula.LOGGER.info("[Nebula/Render] Rendering Iris GPU particles after translucent terrain.");
+            hasLoggedIrisPath = true;
+        }
+
+        //? if >= 1.21 {
+        ClientAnimationManager.getInstance().renderTickFromParticlePhase(camera, tickCounter.getTickDelta(true));
+        //? } else {
+        /*ClientAnimationManager.getInstance().renderTickFromParticlePhase(camera, tickDelta);
+        *///? }
+    }
+
 }

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
@@ -71,10 +71,6 @@ public class NebulaWorldRendererMixin {
 
     @Unique
     private static boolean hasLoggedIrisPath = false;
-    @Unique
-    private static boolean hasLoggedStandardPath = false;
-    @Unique
-    private static boolean hasLoggedIrisFallbackPath = false;
 
     @Inject(method = "render", at = @At(value = "INVOKE",
             shift = At.Shift.AFTER,
@@ -114,17 +110,11 @@ public class NebulaWorldRendererMixin {
         
         *///? }
 
-                if (ModConfig.getInstance().getRenderPipeline() == RenderPipeline.VANILLA_BATCH) {
-                        ClientAnimationManager.getInstance().updateParticlePositions(camera, this.frustum, tickDelta);
+                if (ModConfig.getInstance().getRenderPipeline() != RenderPipeline.VANILLA_BATCH) {
                         return;
                 }
 
-                // 1. Check Iris via Bridge
-                if (!IrisBridge.getInstance().isIrisRenderingActive()) {
-                        return;
-                }
-
-                return;
+                ClientAnimationManager.getInstance().updateParticlePositions(camera, this.frustum, tickDelta);
         }
 
     /**

--- a/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
+++ b/src/main/java/com/atemukesu/nebula/client/mixin/NebulaWorldRendererMixin.java
@@ -73,8 +73,11 @@ public class NebulaWorldRendererMixin {
     private static boolean hasLoggedIrisPath = false;
     @Unique
     private static boolean hasLoggedStandardPath = false;
+    @Unique
+    private static boolean hasLoggedIrisFallbackPath = false;
 
     @Inject(method = "render", at = @At(value = "INVOKE",
+            shift = At.Shift.AFTER,
             //? if < 1.21 {
             
             /*target = "Lnet/minecraft/client/particle/ParticleManager;renderParticles(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider$Immediate;Lnet/minecraft/client/render/LightmapTextureManager;Lnet/minecraft/client/render/Camera;F)V"
@@ -121,45 +124,7 @@ public class NebulaWorldRendererMixin {
                         return;
                 }
 
-                int previousFBO = GL11.glGetInteger(GL30.GL_FRAMEBUFFER_BINDING);
-                boolean isIrisMode = false;
-
-                // 2. Bind Iris Translucent FBO via Bridge (Unified)
-                if (IrisBridge.getInstance().bindTranslucentFramebuffer()) {
-                        isIrisMode = true;
-
-                        if (!hasLoggedIrisPath) {
-                                Nebula.LOGGER.info("[Nebula/Render] ✓ Using Iris render path (Mixin + Iris FBO).");
-                                hasLoggedIrisPath = true;
-                                hasLoggedStandardPath = false;
-                        }
-                }
-
-                if (!isIrisMode) {
-                        return;
-                }
-
-                // 4. 渲染状态设置
-                RenderSystem.enableBlend();
-                RenderSystem.defaultBlendFunc();
-                RenderSystem.disableCull();
-                RenderSystem.depthMask(false);
-
-                // 5. 执行渲染
-                // Iris 模式传入 bindFramebuffer=false (保持 Iris FBO)
-                ClientAnimationManager.getInstance().renderTickMixin(
-                                modelView,
-                                projection,
-                                camera,
-                                this.frustum,
-                                false); // Iris 模式不绑定 MC 主 FBO
-
-                // 6. 恢复状态
-                RenderSystem.enableCull();
-                RenderSystem.depthMask(true);
-
-                // 恢复 FBO
-                GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFBO);
+                return;
         }
 
 }

--- a/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
+++ b/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
@@ -61,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import com.atemukesu.nebula.client.util.IrisUtil;
+import com.atemukesu.nebula.client.shader.IrisShaderToggle;
 
 /**
  * GPU 粒子渲染器 (PMB)
@@ -403,6 +404,7 @@ public class GpuParticleRenderer {
         globalOitCleared = false;
 
         // 2. 正确重置 Shader (必须通知 RenderSystem！)
+        IrisShaderToggle.setActive(false);
         GL20.glUseProgram(0);
         RenderSystem.setShader(() -> null);
 
@@ -482,6 +484,7 @@ public class GpuParticleRenderer {
         // Upload Uniforms
         uploadMatrix(uModelViewMat, modelViewMatrix);
         uploadMatrix(uProjMat, projMatrix);
+        IrisShaderToggle.setActive(true);
         if (uOrigin != -1)
             GL20.glUniform3f(uOrigin, originX, originY, originZ);
         if (uPartialTicks != -1)
@@ -624,6 +627,7 @@ public class GpuParticleRenderer {
         // Upload Common Uniforms
         uploadMatrix(uModelViewMat, modelViewMatrix);
         uploadMatrix(uProjMat, projMatrix);
+        IrisShaderToggle.setActive(true);
         
         // 移除 CameraRight 和 CameraUp 的上传，因为 Shader 现在使用视空间 Billboarding
         // if (uCameraRight != -1)
@@ -667,6 +671,7 @@ public class GpuParticleRenderer {
         RenderSystem.enableCull();
 
         // 3. Reset Shader
+        IrisShaderToggle.setActive(false);
         GL20.glUseProgram(0);
         RenderSystem.setShader(() -> null);
 

--- a/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
+++ b/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
@@ -61,6 +61,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import com.atemukesu.nebula.client.util.IrisUtil;
+import com.atemukesu.nebula.client.bridge.IrisBridge;
 import com.atemukesu.nebula.client.shader.IrisShaderToggle;
 
 /**
@@ -123,7 +124,8 @@ public class GpuParticleRenderer {
     private static int uOitAccum = -1;
     private static int uOitReveal = -1;
 
-    private static final int SSBO_BINDING_INDEX = 0;
+    private static final int SSBO_BINDING_INDEX = 12;
+    private static final int IRIS_PARTICLE_TEXTURE_UNIT = 15;
 
     // 临时矩阵缓冲
     private static final FloatBuffer matrixBuffer = BufferUtils.createFloatBuffer(16);
@@ -308,13 +310,21 @@ public class GpuParticleRenderer {
     private static int globalOitViewportHeight = 0;
     private static final int[] oitCachedViewport = new int[4];
 
+    private static boolean hasLoggedIrisOitBatch = false;
+    private static boolean hasLoggedStandardBatch = false;
+    private static boolean oitUsesExternalProgram = false;
+
     /**
      * 开始 OIT 全局阶段
      * 必须在批量绘制粒子之前调用。
      * 只做初始化，不立即绑定 OIT FBO（因为 Pass 1 需要绘制到主 FBO）
      */
     public static void beginOIT(int targetFboId, int viewportWidth, int viewportHeight) {
-        if (!initialized || oitFbo == null || oitProgram <= 0)
+        beginOIT(targetFboId, viewportWidth, viewportHeight, false);
+    }
+
+    public static void beginOIT(int targetFboId, int viewportWidth, int viewportHeight, boolean useExternalProgram) {
+        if (!initialized || (!useExternalProgram && (oitFbo == null || oitProgram <= 0)))
             return;
 
         RenderSystem.assertOnRenderThread();
@@ -323,8 +333,14 @@ public class GpuParticleRenderer {
         globalOitTargetFboId = targetFboId;
         globalOitActive = true;
         globalOitCleared = false; // 新帧开始，重置清空标志
+        oitUsesExternalProgram = useExternalProgram;
         globalOitViewportWidth = viewportWidth;
         globalOitViewportHeight = viewportHeight;
+
+        if (oitUsesExternalProgram) {
+            GL11.glGetIntegerv(GL11.GL_VIEWPORT, oitCachedViewport);
+            return;
+        }
 
         // 调整 OIT FBO 大小
         oitFbo.resize(viewportWidth, viewportHeight);
@@ -352,10 +368,27 @@ public class GpuParticleRenderer {
      * @param targetFboId 目标 FBO ID
      */
     public static void endOITAndComposite(int targetFboId) {
-        if (!initialized || oitFbo == null || oitProgram <= 0)
+        if (!initialized || (!oitUsesExternalProgram && (oitFbo == null || oitProgram <= 0)))
             return;
 
         RenderSystem.assertOnRenderThread();
+
+        if (oitUsesExternalProgram) {
+            globalOitActive = false;
+            globalOitTargetFboId = -1;
+            globalOitCleared = false;
+            oitUsesExternalProgram = false;
+            IrisShaderToggle.setActive(IrisShaderToggle.currentProgram(), false);
+            GL13.glActiveTexture(GL13.GL_TEXTURE0 + IRIS_PARTICLE_TEXTURE_UNIT);
+            GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, 0);
+            GL13.glActiveTexture(GL13.GL_TEXTURE0);
+            RenderSystem.defaultBlendFunc();
+            RenderSystem.enableCull();
+            RenderSystem.enableDepthTest();
+            RenderSystem.depthMask(true);
+            GL11.glViewport(oitCachedViewport[0], oitCachedViewport[1], oitCachedViewport[2], oitCachedViewport[3]);
+            return;
+        }
 
         // Pass 3: Composite
         if (!IrisUtil.isIrisRenderingActive() && targetFboId == MinecraftClient.getInstance().getFramebuffer().fbo) {
@@ -402,6 +435,7 @@ public class GpuParticleRenderer {
         globalOitActive = false;
         globalOitTargetFboId = -1;
         globalOitCleared = false;
+        oitUsesExternalProgram = false;
 
         // 2. 正确重置 Shader (必须通知 RenderSystem！)
         IrisShaderToggle.setActive(false);
@@ -451,7 +485,7 @@ public class GpuParticleRenderer {
         if (particleCount <= 0 || data == null || !initialized || !shaderCompiled)
             return;
 
-        if (!globalOitActive || oitFbo == null) {
+        if (!globalOitActive || (!oitUsesExternalProgram && oitFbo == null)) {
             Nebula.LOGGER.warn("[GpuParticleRenderer] renderOITBatch called without beginOIT!");
             return;
         }
@@ -469,7 +503,7 @@ public class GpuParticleRenderer {
         // Upload Data
         int ssbo;
         if (useFallback) {
-            ssbo = uploadDataFallback(data, dataSize);
+            ssbo = uploadDataFallback(data);
         } else {
             ssbo = uploadDataPMB(data, dataSize);
         }
@@ -478,80 +512,146 @@ public class GpuParticleRenderer {
         GL30.glBindVertexArray(vao);
         GL30.glBindBufferBase(GL43.GL_SHADER_STORAGE_BUFFER, SSBO_BINDING_INDEX, ssbo);
 
+        int activeProgram = oitUsesExternalProgram ? IrisShaderToggle.currentProgram() : shaderProgram;
+        float currentEmissive = IrisUtil.isIrisRenderingActive() ? ModConfig.getInstance().getEmissiveStrength() : 1.0f;
+
         // Use Particle Shader
-        GL20.glUseProgram(shaderProgram);
+        if (!oitUsesExternalProgram) {
+            GL20.glUseProgram(shaderProgram);
+            activeProgram = shaderProgram;
+        }
+        if (!hasLoggedIrisOitBatch) {
+            Nebula.LOGGER.info("[GpuParticleRenderer] OIT batch start: program={}, particles={}, targetFbo={}, irisActive={}, externalProgram={}",
+                    activeProgram, particleCount, globalOitTargetFboId, IrisUtil.isIrisRenderingActive(), oitUsesExternalProgram);
+            hasLoggedIrisOitBatch = true;
+        }
 
         // Upload Uniforms
-        uploadMatrix(uModelViewMat, modelViewMatrix);
-        uploadMatrix(uProjMat, projMatrix);
-        IrisShaderToggle.setActive(true);
-        if (uOrigin != -1)
+        if (oitUsesExternalProgram) {
+            IrisShaderToggle.bindParticleBufferBlock(activeProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(activeProgram, modelViewMatrix, projMatrix, originX, originY, originZ, partialTicks);
+        } else {
+            uploadMatrix(uModelViewMat, modelViewMatrix);
+            uploadMatrix(uProjMat, projMatrix);
+        }
+        IrisShaderToggle.setActive(activeProgram, true);
+        if (uOrigin != -1 && !oitUsesExternalProgram)
             GL20.glUniform3f(uOrigin, originX, originY, originZ);
-        if (uPartialTicks != -1)
+        if (uPartialTicks != -1 && !oitUsesExternalProgram)
             GL20.glUniform1f(uPartialTicks, partialTicks);
 
         // 动态设置 HDR 强度: Iris 开启时使用用户自定义的亮度，关闭时保持原色(1.0)
-        // 移至此处以确保同时应用于 Pass 1 (Opaque) 和 Pass 2 (Translucent)
-        float currentEmissive = IrisUtil.isIrisRenderingActive() ? ModConfig.getInstance().getEmissiveStrength() : 1.0f;
-        if (uEmissiveStrength != -1)
+        if (oitUsesExternalProgram) {
+            IrisShaderToggle.uploadNebulaMaterialUniforms(activeProgram, useTexture && glTextureId > 0, currentEmissive, 0, IRIS_PARTICLE_TEXTURE_UNIT);
+        } else if (uEmissiveStrength != -1)
             GL20.glUniform1f(uEmissiveStrength, currentEmissive);
 
         // Textures
+        int textureUnit = oitUsesExternalProgram ? IRIS_PARTICLE_TEXTURE_UNIT : 0;
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + textureUnit);
         if (useTexture && glTextureId > 0) {
-            GL13.glActiveTexture(GL13.GL_TEXTURE0);
             GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, glTextureId);
-            if (uSampler0 != -1)
-                GL20.glUniform1i(uSampler0, 0);
-            if (uUseTexture != -1)
-                GL20.glUniform1i(uUseTexture, 1);
+            if (!oitUsesExternalProgram) {
+                if (uSampler0 != -1)
+                    GL20.glUniform1i(uSampler0, 0);
+                if (uUseTexture != -1)
+                    GL20.glUniform1i(uUseTexture, 1);
+            }
         } else {
-            if (uUseTexture != -1)
+            GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, 0);
+            if (!oitUsesExternalProgram && uUseTexture != -1)
                 GL20.glUniform1i(uUseTexture, 0);
         }
+        GL13.glActiveTexture(GL13.GL_TEXTURE0);
 
         RenderSystem.disableCull();
         RenderSystem.enableDepthTest();
         RenderSystem.depthFunc(GL11.GL_LEQUAL);
 
-        // ==========================================
-        // Pass 1: 不透明粒子 (Opaque)
-        // 目标: 主 FBO
-        // ==========================================
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, globalOitTargetFboId);
-        if (uRenderPass != -1)
-            GL20.glUniform1i(uRenderPass, 0); // Opaque Pass
+        if (oitUsesExternalProgram) {
+            GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, globalOitTargetFboId);
+            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(false);
+            if (opaqueProgram <= 0) {
+                opaqueProgram = activeProgram;
+                GL20.glUseProgram(opaqueProgram);
+            }
+            IrisShaderToggle.bindParticleBufferBlock(opaqueProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(opaqueProgram, modelViewMatrix, projMatrix,
+                    originX, originY, originZ, partialTicks);
+            IrisShaderToggle.setActive(opaqueProgram, true);
+            IrisShaderToggle.uploadNebulaMaterialUniforms(
+                    opaqueProgram,
+                    useTexture && glTextureId > 0,
+                    currentEmissive,
+                    0,
+                    IRIS_PARTICLE_TEXTURE_UNIT);
+            RenderSystem.depthMask(true);
+            RenderSystem.enableBlend();
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+            );
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
-        RenderSystem.depthMask(true);
-        RenderSystem.enableBlend();
+            IrisShaderToggle.setActive(opaqueProgram, false);
+            int translucentProgram = IrisBridge.getInstance().bindParticleShader(true);
+            if (translucentProgram <= 0) {
+                translucentProgram = activeProgram;
+                GL20.glUseProgram(translucentProgram);
+            }
+            IrisShaderToggle.bindParticleBufferBlock(translucentProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(translucentProgram, modelViewMatrix, projMatrix,
+                    originX, originY, originZ, partialTicks);
+            IrisShaderToggle.setActive(translucentProgram, true);
+            IrisShaderToggle.uploadNebulaMaterialUniforms(
+                    translucentProgram,
+                    useTexture && glTextureId > 0,
+                    currentEmissive,
+                    3,
+                    IRIS_PARTICLE_TEXTURE_UNIT);
+            RenderSystem.depthMask(false);
+            RenderSystem.enableBlend();
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+            );
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+        } else {
+            // ==========================================
+            // Pass 1: 不透明粒子 (Opaque)
+            // 目标: 主 FBO
+            // ==========================================
+            GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, globalOitTargetFboId);
+            if (uRenderPass != -1)
+                GL20.glUniform1i(uRenderPass, 0);
 
-        // 核心修复：分离混合，保护主 FBO 的 Alpha 通道不被污染
-        RenderSystem.blendFuncSeparate(
-                GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-        );
+            RenderSystem.depthMask(true);
+            RenderSystem.enableBlend();
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+            );
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
-        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
-        // ==========================================
-        // Pass 2: 半透明粒子 (Translucent)
-        // 目标: OIT FBO
-        // ==========================================
-        oitFbo.bindAndShareDepth(globalOitTargetFboId);
-        // 只在第一个 batch 时清空 OIT FBO
-        if (!globalOitCleared) {
-            oitFbo.clear();
-            globalOitCleared = true;
+            // ==========================================
+            // Pass 2: 半透明粒子 (Translucent)
+            // 目标: OIT FBO
+            // ==========================================
+            oitFbo.bindAndShareDepth(globalOitTargetFboId);
+            if (!globalOitCleared) {
+                oitFbo.clear();
+                globalOitCleared = true;
+            }
+
+            if (uRenderPass != -1)
+                GL20.glUniform1i(uRenderPass, 1);
+
+            RenderSystem.depthMask(false);
+            RenderSystem.enableBlend();
+            GL40.glBlendFunci(0, GL11.GL_ONE, GL11.GL_ONE);
+            GL40.glBlendFunci(1, GL11.GL_ZERO, GL11.GL_ONE_MINUS_SRC_COLOR);
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
         }
-
-        if (uRenderPass != -1)
-            GL20.glUniform1i(uRenderPass, 1); // Translucent Pass
-
-        RenderSystem.depthMask(false); // OIT 核心：不写深度
-        RenderSystem.enableBlend();
-        // OIT 专用混合模式
-        GL40.glBlendFunci(0, GL11.GL_ONE, GL11.GL_ONE); // Accum
-        GL40.glBlendFunci(1, GL11.GL_ZERO, GL11.GL_ONE_MINUS_SRC_COLOR); // Reveal
-
-        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
         // Cleanup (部分，完整清理在 endOITAndComposite 中)
         GL30.glBindBufferBase(GL43.GL_SHADER_STORAGE_BUFFER, SSBO_BINDING_INDEX, 0);
@@ -583,8 +683,12 @@ public class GpuParticleRenderer {
 
     // Standard Batch Rendering State
     private static boolean standardBatchActive = false;
+    private static boolean standardBatchUsesExternalProgram = false;
+    private static int standardExternalProgram = -1;
     private static int standardRestoreFboId = -1;
     private static int[] standardViewport = new int[4];
+    private static Matrix4f standardExternalModelView;
+    private static Matrix4f standardExternalProjection;
 
     /**
      * 开始标准渲染批量 (Standard/Additive)
@@ -596,9 +700,12 @@ public class GpuParticleRenderer {
      * @param restoreFboId 渲染结束后需要恢复的 FBO ID。如果为 -1，则不执行恢复。
      */
     public static void beginStandardRendering(Matrix4f modelViewMatrix, Matrix4f projMatrix,
-            // 移除 cameraRight 和 cameraUp 参数，因为现在使用视空间 Billboarding
-            // float[] cameraRight, float[] cameraUp, 
             int restoreFboId) {
+        beginStandardRendering(modelViewMatrix, projMatrix, restoreFboId, false);
+    }
+
+    public static void beginStandardRendering(Matrix4f modelViewMatrix, Matrix4f projMatrix,
+            int restoreFboId, boolean useExternalProgram) {
         if (!initialized || !shaderCompiled)
             return;
 
@@ -610,7 +717,11 @@ public class GpuParticleRenderer {
         }
 
         standardBatchActive = true;
+        standardBatchUsesExternalProgram = useExternalProgram;
+        standardExternalProgram = -1;
         standardRestoreFboId = restoreFboId;
+        standardExternalModelView = modelViewMatrix == null ? null : new Matrix4f(modelViewMatrix);
+        standardExternalProjection = projMatrix == null ? null : new Matrix4f(projMatrix);
 
         // Backup Viewport
         GL11.glGetIntegerv(GL11.GL_VIEWPORT, standardViewport);
@@ -620,25 +731,39 @@ public class GpuParticleRenderer {
         RenderSystem.enableDepthTest();
         RenderSystem.depthFunc(GL11.GL_LEQUAL);
 
-        // Bind Shader & VAO
-        GL20.glUseProgram(shaderProgram);
+        int currentProgram = IrisShaderToggle.currentProgram();
+        if (standardBatchUsesExternalProgram) {
+            standardExternalProgram = currentProgram;
+            int blockIndex = GL43.glGetProgramResourceIndex(currentProgram, GL43.GL_SHADER_STORAGE_BLOCK, "NebulaParticleBuffer");
+            IrisShaderToggle.bindParticleBufferBlock(currentProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(currentProgram, modelViewMatrix, projMatrix, 0.0f, 0.0f, 0.0f, 0.0f);
+        } else {
+            GL20.glUseProgram(shaderProgram);
+            currentProgram = shaderProgram;
+            uploadMatrix(uModelViewMat, modelViewMatrix);
+            uploadMatrix(uProjMat, projMatrix);
+        }
         GL30.glBindVertexArray(vao);
+        IrisShaderToggle.setActive(currentProgram, true);
+        if (!hasLoggedStandardBatch) {
+            Nebula.LOGGER.info("[GpuParticleRenderer] Standard batch ready: program={}, restoreFbo={}, irisActive={}, externalProgram={}",
+                    currentProgram, standardRestoreFboId, IrisUtil.isIrisRenderingActive(), standardBatchUsesExternalProgram);
+            hasLoggedStandardBatch = true;
+        }
 
-        // Upload Common Uniforms
-        uploadMatrix(uModelViewMat, modelViewMatrix);
-        uploadMatrix(uProjMat, projMatrix);
-        IrisShaderToggle.setActive(true);
-        
         // 移除 CameraRight 和 CameraUp 的上传，因为 Shader 现在使用视空间 Billboarding
         // if (uCameraRight != -1)
         //     GL20.glUniform3f(uCameraRight, cameraRight[0], cameraRight[1], cameraRight[2]);
         // if (uCameraUp != -1)
         //     GL20.glUniform3f(uCameraUp, cameraUp[0], cameraUp[1], cameraUp[2]);
 
-        // Emissive Strength
         float currentEmissive = IrisUtil.isIrisRenderingActive() ? ModConfig.getInstance().getEmissiveStrength() : 1.0f;
-        if (uEmissiveStrength != -1)
-            GL20.glUniform1f(uEmissiveStrength, currentEmissive);
+        if (standardBatchUsesExternalProgram) {
+            IrisShaderToggle.uploadNebulaMaterialUniforms(currentProgram, true, currentEmissive, 2, IRIS_PARTICLE_TEXTURE_UNIT);
+        } else {
+            if (uEmissiveStrength != -1)
+                GL20.glUniform1f(uEmissiveStrength, currentEmissive);
+        }
     }
 
     /**
@@ -670,10 +795,16 @@ public class GpuParticleRenderer {
         RenderSystem.depthMask(true);
         RenderSystem.enableCull();
 
-        // 3. Reset Shader
-        IrisShaderToggle.setActive(false);
-        GL20.glUseProgram(0);
-        RenderSystem.setShader(() -> null);
+        if (!standardBatchUsesExternalProgram) {
+            IrisShaderToggle.setActive(false);
+            GL20.glUseProgram(0);
+            RenderSystem.setShader(() -> null);
+        } else {
+            IrisShaderToggle.setActive(standardExternalProgram, false);
+            GL13.glActiveTexture(GL13.GL_TEXTURE0 + IRIS_PARTICLE_TEXTURE_UNIT);
+            GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, 0);
+            GL13.glActiveTexture(GL13.GL_TEXTURE0);
+        }
 
         // 4. Restore Viewport
         GL11.glViewport(standardViewport[0], standardViewport[1], standardViewport[2], standardViewport[3]);
@@ -690,7 +821,10 @@ public class GpuParticleRenderer {
         }
 
         standardBatchActive = false;
+        standardExternalProgram = -1;
         standardRestoreFboId = -1;
+        standardExternalModelView = null;
+        standardExternalProjection = null;
     }
 
     /**
@@ -723,7 +857,7 @@ public class GpuParticleRenderer {
 
         int ssbo;
         if (useFallback) {
-            ssbo = uploadDataFallback(data, dataSize);
+            ssbo = uploadDataFallback(data);
         } else {
             ssbo = uploadDataPMB(data, dataSize);
         }
@@ -731,62 +865,126 @@ public class GpuParticleRenderer {
         // Bind SSBO
         GL30.glBindBufferBase(GL43.GL_SHADER_STORAGE_BUFFER, SSBO_BINDING_INDEX, ssbo);
 
-        // Upload Instance-Specific Uniforms
-        if (uOrigin != -1)
-            GL20.glUniform3f(uOrigin, originX, originY, originZ);
-        if (uPartialTicks != -1)
-            GL20.glUniform1f(uPartialTicks, partialTicks);
+        int activeProgram = standardBatchUsesExternalProgram ? standardExternalProgram : shaderProgram;
+        float currentEmissive = IrisUtil.isIrisRenderingActive() ? ModConfig.getInstance().getEmissiveStrength() : 1.0f;
+
+        if (standardBatchUsesExternalProgram) {
+            if (activeProgram <= 0) {
+                Nebula.LOGGER.warn("[GpuParticleRenderer] Skipping Iris standard batch because no external particle program was captured.");
+                return;
+            }
+            IrisShaderToggle.uploadNebulaUniforms(activeProgram, null, null, originX, originY, originZ, partialTicks);
+        } else {
+            if (uOrigin != -1)
+                GL20.glUniform3f(uOrigin, originX, originY, originZ);
+            if (uPartialTicks != -1)
+                GL20.glUniform1f(uPartialTicks, partialTicks);
+        }
 
         // Texture Binding
+        int textureUnit = standardBatchUsesExternalProgram ? IRIS_PARTICLE_TEXTURE_UNIT : 0;
+        GL13.glActiveTexture(GL13.GL_TEXTURE0 + textureUnit);
         if (useTexture && glTextureId > 0) {
-            GL13.glActiveTexture(GL13.GL_TEXTURE0);
             GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, glTextureId);
-            if (uSampler0 != -1)
-                GL20.glUniform1i(uSampler0, 0);
-            if (uUseTexture != -1)
-                GL20.glUniform1i(uUseTexture, 1);
+            if (!standardBatchUsesExternalProgram) {
+                if (uSampler0 != -1)
+                    GL20.glUniform1i(uSampler0, 0);
+                if (uUseTexture != -1)
+                    GL20.glUniform1i(uUseTexture, 1);
+            }
         } else {
             GL11.glBindTexture(GL30.GL_TEXTURE_2D_ARRAY, 0);
-            if (uUseTexture != -1)
+            if (!standardBatchUsesExternalProgram && uUseTexture != -1)
                 GL20.glUniform1i(uUseTexture, 0);
         }
+        GL13.glActiveTexture(GL13.GL_TEXTURE0);
 
         // Drawing Passes (2-Pass: Opaque + Translucent)
         BlendMode blendMode = ModConfig.getInstance().getBlendMode();
 
-        // Pass 1: Opaque
-        if (uRenderPass != -1)
-            GL20.glUniform1i(uRenderPass, 0); // Opaque Pass
+        if (standardBatchUsesExternalProgram) {
+            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(false);
+            if (opaqueProgram <= 0) {
+                opaqueProgram = activeProgram;
+                GL20.glUseProgram(opaqueProgram);
+            }
+            IrisShaderToggle.bindParticleBufferBlock(opaqueProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(opaqueProgram, standardExternalModelView,
+                    standardExternalProjection, originX, originY, originZ, partialTicks);
+            IrisShaderToggle.setActive(opaqueProgram, true);
+            IrisShaderToggle.uploadNebulaMaterialUniforms(opaqueProgram, useTexture && glTextureId > 0, currentEmissive, 0, IRIS_PARTICLE_TEXTURE_UNIT);
+            RenderSystem.depthMask(true);
+            RenderSystem.enableBlend();
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+            );
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
-        RenderSystem.depthMask(true);
-        RenderSystem.enableBlend();
-        RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
+            IrisShaderToggle.setActive(opaqueProgram, false);
+            int translucentProgram = IrisBridge.getInstance().bindParticleShader(true);
+            if (translucentProgram <= 0) {
+                translucentProgram = activeProgram;
+                GL20.glUseProgram(translucentProgram);
+            }
+            IrisShaderToggle.bindParticleBufferBlock(translucentProgram, SSBO_BINDING_INDEX);
+            IrisShaderToggle.uploadNebulaUniforms(translucentProgram, standardExternalModelView,
+                    standardExternalProjection, originX, originY, originZ, partialTicks);
+            IrisShaderToggle.setActive(translucentProgram, true);
+            IrisShaderToggle.uploadNebulaMaterialUniforms(translucentProgram, useTexture && glTextureId > 0, currentEmissive, 3, IRIS_PARTICLE_TEXTURE_UNIT);
+            RenderSystem.depthMask(false);
+            switch (blendMode) {
+                case ADDITIVE:
+                    RenderSystem.blendFuncSeparate(
+                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE,
+                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+                    );
+                    break;
+                case ALPHA:
+                default:
+                    RenderSystem.blendFuncSeparate(
+                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+                    );
+                    break;
+            }
 
-        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+        } else {
+            // Pass 1: Opaque
+            if (uRenderPass != -1)
+                GL20.glUniform1i(uRenderPass, 0); // Opaque Pass
 
-        // Pass 2: Translucent
-        if (uRenderPass != -1)
-            GL20.glUniform1i(uRenderPass, 2); // Translucent Pass (Standard)
+            RenderSystem.depthMask(true);
+            RenderSystem.enableBlend();
+            RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
 
-        RenderSystem.depthMask(false);
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
-        switch (blendMode) {
-            case ADDITIVE:
-                RenderSystem.blendFuncSeparate(
-                        GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE,
-                        GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-                );
-                break;
-            case ALPHA:
-            default:
-                RenderSystem.blendFuncSeparate(
-                        GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                        GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-                );
-                break;
+            // Pass 2: Translucent
+            if (uRenderPass != -1)
+                GL20.glUniform1i(uRenderPass, 2); // Translucent Pass (Standard)
+
+            RenderSystem.depthMask(false);
+
+            switch (blendMode) {
+                case ADDITIVE:
+                    RenderSystem.blendFuncSeparate(
+                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE,
+                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+                    );
+                    break;
+                case ALPHA:
+                default:
+                    RenderSystem.blendFuncSeparate(
+                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
+                    );
+                    break;
+            }
+
+            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
         }
-
-        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
         // Stats
         PerformanceStats stats = PerformanceStats.getInstance();
@@ -841,6 +1039,8 @@ public class GpuParticleRenderer {
         long destAddress = MemoryUtil.memAddress(mappedBuffer);
         long srcAddress = MemoryUtil.memAddress(data);
         MemoryUtil.memCopy(srcAddress, destAddress, dataSize);
+        // 确保 CPU 写入对 GPU 可见 (Persistent Mapped Buffer 需要)
+        GL42.glMemoryBarrier(GL42.GL_ALL_BARRIER_BITS);
         stats.endDataUpload(); // 计时
         return ssbos[bufferIndex];
     }
@@ -848,7 +1048,7 @@ public class GpuParticleRenderer {
     /**
      * 降级模式数据上传（传统 glBufferSubData）
      */
-    private static int uploadDataFallback(ByteBuffer data, int dataSize) {
+    private static int uploadDataFallback(ByteBuffer data) {
         PerformanceStats stats = PerformanceStats.getInstance();
         stats.beginDataUpload(); // 统计数据
         GL15.glBindBuffer(GL43.GL_SHADER_STORAGE_BUFFER, ssbos[0]);
@@ -859,6 +1059,7 @@ public class GpuParticleRenderer {
         // 写入数据
         GL15.glBufferSubData(GL43.GL_SHADER_STORAGE_BUFFER, 0, data);
         GL15.glBindBuffer(GL43.GL_SHADER_STORAGE_BUFFER, 0);
+        GL42.glMemoryBarrier(GL42.GL_ALL_BARRIER_BITS);
         stats.endDataUpload(); // 计时
         return ssbos[0];
     }
@@ -916,31 +1117,6 @@ public class GpuParticleRenderer {
         }
     }
 
-    /**
-     * 清理渲染器
-     */
-    public static void cleanup() {
-        cleanupBuffers();
-
-        if (vao != -1) {
-            GL30.glDeleteVertexArrays(vao);
-            vao = -1;
-        }
-        if (quadVbo != -1) {
-            GL15.glDeleteBuffers(quadVbo);
-            quadVbo = -1;
-        }
-        if (shaderProgram > 0) {
-            GL20.glDeleteProgram(shaderProgram);
-            shaderProgram = -1;
-        }
-
-        initialized = false;
-        shaderCompiled = false;
-        pmbSupported = false;
-        useFallback = false;
-    }
-
     private static String loadShaderSource(Identifier id) {
         try {
             Optional<net.minecraft.resource.Resource> resource = MinecraftClient.getInstance().getResourceManager()
@@ -976,7 +1152,7 @@ public class GpuParticleRenderer {
         String fragmentSource = loadShaderSource(fshId);
         if (vertexSource == null || fragmentSource == null)
             return -1;
-        int vertexShader = 0, fragmentShader = 0, program = 0;
+        int vertexShader = 0, fragmentShader = 0, program;
         try {
             vertexShader = GL20.glCreateShader(GL20.GL_VERTEX_SHADER);
             GL20.glShaderSource(vertexShader, vertexSource);
@@ -1019,27 +1195,6 @@ public class GpuParticleRenderer {
     }
 
     /**
-     * 检查是否初始化
-     * 
-     * @return 是否初始化
-     */
-    public static boolean isInitialized() {
-        return initialized;
-    }
-
-    public static boolean isShaderCompiled() {
-        return shaderCompiled;
-    }
-
-    public static int getBufferSize() {
-        return currentBufferSize;
-    }
-
-    public static int getTypeSize() {
-        return lastFrameUsedBytes;
-    }
-
-    /**
      * 预分配 OIT 资源
      * 
      * @param width  视口宽度
@@ -1056,12 +1211,4 @@ public class GpuParticleRenderer {
         GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
     }
 
-    /**
-     * 检查是否支持 PMB
-     * 
-     * @return 是否支持 PMB
-     */
-    public static boolean isPMBSupported() {
-        return pmbSupported && !useFallback;
-    }
 }

--- a/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
+++ b/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
@@ -315,6 +315,58 @@ public class GpuParticleRenderer {
     private static boolean oitUsesExternalProgram = false;
 
     /**
+     * Iris shader binding is allowed to apply its own GL state.  Re-establish the
+     * vanilla particle depth contract after that binding and immediately before a
+     * Nebula draw, so the transparent pass never inherits a disabled/decal depth
+     * test from an earlier shaderpack pass.
+     */
+    private static void prepareParticleDepthState() {
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthFunc(GL11.GL_LEQUAL);
+    }
+
+    /**
+     * Iris transparent targets are composited again later in the shaderpack.
+     * Keep their alpha channel with the color by using premultiplied-alpha
+     * blending.  The old SRC_ALPHA/.../ZERO,ONE setup never updated destination
+     * alpha, so later sky/fog composition could overwrite translucent particles.
+     */
+    private static void prepareIrisParticleBlendState(BlendMode blendMode) {
+        RenderSystem.enableBlend();
+        if (blendMode == BlendMode.ADDITIVE) {
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE,
+                    GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA
+            );
+        } else {
+            RenderSystem.blendFuncSeparate(
+                    GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
+                    GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA
+            );
+        }
+    }
+
+    /**
+     * The opaque pass remains visible at the horizon because it writes depth.
+     * Give the low-alpha pass the same protection without putting any color into
+     * the depth pre-pass: first write only the surviving fragment depth, then
+     * blend exactly those fragments into Iris' transparent target.
+     */
+    private static void drawIrisTranslucentParticles(int particleCount, BlendMode blendMode) {
+        prepareParticleDepthState();
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(true);
+        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+
+        RenderSystem.colorMask(true, true, true, true);
+        RenderSystem.depthFunc(GL11.GL_EQUAL);
+        RenderSystem.depthMask(false);
+        prepareIrisParticleBlendState(blendMode);
+        GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+        RenderSystem.depthFunc(GL11.GL_LEQUAL);
+    }
+
+    /**
      * 开始 OIT 全局阶段
      * 必须在批量绘制粒子之前调用。
      * 只做初始化，不立即绑定 OIT FBO（因为 Pass 1 需要绘制到主 FBO）
@@ -374,6 +426,15 @@ public class GpuParticleRenderer {
         RenderSystem.assertOnRenderThread();
 
         if (oitUsesExternalProgram) {
+            // [FIX] 恢复 FBO 到原始目标（bindTranslucentFramebuffer 可能已切换 FBO）
+            if (globalOitTargetFboId >= 0) {
+                if (globalOitTargetFboId == MinecraftClient.getInstance().getFramebuffer().fbo) {
+                    MinecraftClient.getInstance().getFramebuffer().beginWrite(false);
+                } else {
+                    GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, globalOitTargetFboId);
+                }
+            }
+
             globalOitActive = false;
             globalOitTargetFboId = -1;
             globalOitCleared = false;
@@ -570,7 +631,10 @@ public class GpuParticleRenderer {
 
         if (oitUsesExternalProgram) {
             GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, globalOitTargetFboId);
-            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(false);
+            // Nebula is injected while Iris is in the PARTICLES phase.  Switching
+            // only the program to PARTICLES does not also switch Iris' framebuffer
+            // routing, so keep this draw in the phase's particles_trans program.
+            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(true);
             if (opaqueProgram <= 0) {
                 opaqueProgram = activeProgram;
                 GL20.glUseProgram(opaqueProgram);
@@ -585,18 +649,18 @@ public class GpuParticleRenderer {
                     currentEmissive,
                     0,
                     IRIS_PARTICLE_TEXTURE_UNIT);
+            prepareParticleDepthState();
             RenderSystem.depthMask(true);
-            RenderSystem.enableBlend();
-            RenderSystem.blendFuncSeparate(
-                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-            );
+            prepareIrisParticleBlendState(BlendMode.ALPHA);
             GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
             IrisShaderToggle.setActive(opaqueProgram, false);
+
+            // 透明粒子必须回到 Iris 的 particles_trans 程序。仅切换 GL program
+            // 到 PARTICLES 会把片段送到错误的 shaderpack 渲染目标，不能用于透明层。
             int translucentProgram = IrisBridge.getInstance().bindParticleShader(true);
             if (translucentProgram <= 0) {
-                translucentProgram = activeProgram;
+                translucentProgram = opaqueProgram;
                 GL20.glUseProgram(translucentProgram);
             }
             IrisShaderToggle.bindParticleBufferBlock(translucentProgram, SSBO_BINDING_INDEX);
@@ -609,13 +673,7 @@ public class GpuParticleRenderer {
                     currentEmissive,
                     3,
                     IRIS_PARTICLE_TEXTURE_UNIT);
-            RenderSystem.depthMask(false);
-            RenderSystem.enableBlend();
-            RenderSystem.blendFuncSeparate(
-                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-            );
-            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+            drawIrisTranslucentParticles(particleCount, BlendMode.ALPHA);
         } else {
             // ==========================================
             // Pass 1: 不透明粒子 (Opaque)
@@ -900,10 +958,12 @@ public class GpuParticleRenderer {
         GL13.glActiveTexture(GL13.GL_TEXTURE0);
 
         // Drawing Passes (2-Pass: Opaque + Translucent)
-        BlendMode blendMode = ModConfig.getInstance().getBlendMode();
+        BlendMode blendMode = ModConfig.getInstance().getEffectiveBlendMode();
 
         if (standardBatchUsesExternalProgram) {
-            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(false);
+            // See the OIT path: program-only switching to PARTICLES mismatches the
+            // framebuffer selected by the active Iris PARTICLES phase.
+            int opaqueProgram = IrisBridge.getInstance().bindParticleShader(true);
             if (opaqueProgram <= 0) {
                 opaqueProgram = activeProgram;
                 GL20.glUseProgram(opaqueProgram);
@@ -913,18 +973,18 @@ public class GpuParticleRenderer {
                     standardExternalProjection, originX, originY, originZ, partialTicks);
             IrisShaderToggle.setActive(opaqueProgram, true);
             IrisShaderToggle.uploadNebulaMaterialUniforms(opaqueProgram, useTexture && glTextureId > 0, currentEmissive, 0, IRIS_PARTICLE_TEXTURE_UNIT);
+            prepareParticleDepthState();
             RenderSystem.depthMask(true);
-            RenderSystem.enableBlend();
-            RenderSystem.blendFuncSeparate(
-                    GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                    GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-            );
+            prepareIrisParticleBlendState(blendMode);
             GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
 
             IrisShaderToggle.setActive(opaqueProgram, false);
+
+            // 透明粒子必须使用 Iris 的 particles_trans 程序，确保写入 shaderpack
+            // 为粒子透明层配置的渲染目标。
             int translucentProgram = IrisBridge.getInstance().bindParticleShader(true);
             if (translucentProgram <= 0) {
-                translucentProgram = activeProgram;
+                translucentProgram = opaqueProgram;
                 GL20.glUseProgram(translucentProgram);
             }
             IrisShaderToggle.bindParticleBufferBlock(translucentProgram, SSBO_BINDING_INDEX);
@@ -932,24 +992,7 @@ public class GpuParticleRenderer {
                     standardExternalProjection, originX, originY, originZ, partialTicks);
             IrisShaderToggle.setActive(translucentProgram, true);
             IrisShaderToggle.uploadNebulaMaterialUniforms(translucentProgram, useTexture && glTextureId > 0, currentEmissive, 3, IRIS_PARTICLE_TEXTURE_UNIT);
-            RenderSystem.depthMask(false);
-            switch (blendMode) {
-                case ADDITIVE:
-                    RenderSystem.blendFuncSeparate(
-                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE,
-                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-                    );
-                    break;
-                case ALPHA:
-                default:
-                    RenderSystem.blendFuncSeparate(
-                            GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA,
-                            GlStateManager.SrcFactor.ZERO, GlStateManager.DstFactor.ONE
-                    );
-                    break;
-            }
-
-            GL31.glDrawArraysInstanced(GL11.GL_TRIANGLE_FAN, 0, 4, particleCount);
+            drawIrisTranslucentParticles(particleCount, blendMode);
         } else {
             // Pass 1: Opaque
             if (uRenderPass != -1)

--- a/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
+++ b/src/main/java/com/atemukesu/nebula/client/render/GpuParticleRenderer.java
@@ -1083,7 +1083,7 @@ public class GpuParticleRenderer {
         long srcAddress = MemoryUtil.memAddress(data);
         MemoryUtil.memCopy(srcAddress, destAddress, dataSize);
         // 确保 CPU 写入对 GPU 可见 (Persistent Mapped Buffer 需要)
-        GL42.glMemoryBarrier(GL42.GL_ALL_BARRIER_BITS);
+        GL42.glMemoryBarrier(GL43.GL_SHADER_STORAGE_BARRIER_BIT);
         stats.endDataUpload(); // 计时
         return ssbos[bufferIndex];
     }
@@ -1102,7 +1102,7 @@ public class GpuParticleRenderer {
         // 写入数据
         GL15.glBufferSubData(GL43.GL_SHADER_STORAGE_BUFFER, 0, data);
         GL15.glBindBuffer(GL43.GL_SHADER_STORAGE_BUFFER, 0);
-        GL42.glMemoryBarrier(GL42.GL_ALL_BARRIER_BITS);
+        GL42.glMemoryBarrier(GL43.GL_SHADER_STORAGE_BARRIER_BIT);
         stats.endDataUpload(); // 计时
         return ssbos[0];
     }

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderToggle.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderToggle.java
@@ -1,0 +1,24 @@
+package com.atemukesu.nebula.client.shader;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL20;
+
+public final class IrisShaderToggle {
+
+    private static final String UNIFORM_NAME = "NebulaIsActive";
+
+    private IrisShaderToggle() {
+    }
+
+    public static void setActive(boolean active) {
+        int program = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+        if (program <= 0) {
+            return;
+        }
+
+        int location = GL20.glGetUniformLocation(program, UNIFORM_NAME);
+        if (location >= 0) {
+            GL20.glUniform1i(location, active ? 1 : 0);
+        }
+    }
+}

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderToggle.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderToggle.java
@@ -1,24 +1,113 @@
 package com.atemukesu.nebula.client.shader;
 
+import com.atemukesu.nebula.Nebula;
+import org.joml.Matrix4f;
+import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL20;
+import org.lwjgl.opengl.GL43;
+
+import java.nio.FloatBuffer;
 
 public final class IrisShaderToggle {
 
     private static final String UNIFORM_NAME = "NebulaIsActive";
+    private static final FloatBuffer MATRIX_BUFFER = BufferUtils.createFloatBuffer(16);
+    private static boolean loggedMissingUniform = false;
+    private static boolean loggedMissingProgram = false;
+    private static boolean loggedAppliedUniform = false;
 
     private IrisShaderToggle() {
     }
 
+    public static int currentProgram() {
+        return GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+    }
+
     public static void setActive(boolean active) {
-        int program = GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM);
+        setActive(currentProgram(), active);
+    }
+
+    public static void setActive(int program, boolean active) {
         if (program <= 0) {
+            if (active && !loggedMissingProgram) {
+                Nebula.LOGGER.warn("[Nebula/Iris] Tried to toggle NebulaIsActive without an active GL program.");
+                loggedMissingProgram = true;
+            }
             return;
         }
 
         int location = GL20.glGetUniformLocation(program, UNIFORM_NAME);
         if (location >= 0) {
             GL20.glUniform1i(location, active ? 1 : 0);
+            if (active && !loggedAppliedUniform) {
+                Nebula.LOGGER.info("[Nebula/Iris] Applied NebulaIsActive=1 to GL program {} at location {}.", program, location);
+                loggedAppliedUniform = true;
+            }
+            return;
+        }
+
+        if (active && !loggedMissingUniform) {
+            Nebula.LOGGER.warn("[Nebula/Iris] Active GL program {} does not expose NebulaIsActive.", program);
+            loggedMissingUniform = true;
+        }
+    }
+
+    public static void bindParticleBufferBlock(int program, int bindingIndex) {
+        if (program <= 0) {
+            return;
+        }
+        int blockIndex = GL43.glGetProgramResourceIndex(program, GL43.GL_SHADER_STORAGE_BLOCK, "NebulaParticleBuffer");
+        if (blockIndex != -1) {
+            GL43.glShaderStorageBlockBinding(program, blockIndex, bindingIndex);
+        }
+    }
+
+    public static void uploadNebulaUniforms(int program, Matrix4f modelViewMatrix, Matrix4f projMatrix,
+            float originX, float originY, float originZ, float partialTicks) {
+        uploadMatrix(program, "NebulaModelViewMat", modelViewMatrix);
+        uploadMatrix(program, "NebulaProjMat", projMatrix);
+        uploadVec3(program, "NebulaOrigin", originX, originY, originZ);
+        uploadFloat(program, "NebulaPartialTicks", partialTicks);
+    }
+
+    public static void uploadNebulaMaterialUniforms(int program, boolean useTexture, float emissiveStrength,
+            int renderPass, int textureUnit) {
+        uploadInt(program, "NebulaUseTexture", useTexture ? 1 : 0);
+        uploadFloat(program, "NebulaEmissiveStrength", emissiveStrength);
+        uploadInt(program, "NebulaRenderPass", renderPass);
+        uploadInt(program, "NebulaSampler0", textureUnit);
+    }
+
+    private static void uploadMatrix(int program, String name, Matrix4f matrix) {
+        int location = GL20.glGetUniformLocation(program, name);
+        if (location < 0 || matrix == null) {
+            return;
+        }
+        MATRIX_BUFFER.clear();
+        matrix.get(MATRIX_BUFFER);
+        MATRIX_BUFFER.rewind();
+        GL20.glUniformMatrix4fv(location, false, MATRIX_BUFFER);
+    }
+
+    private static void uploadVec3(int program, String name, float x, float y, float z) {
+        int location = GL20.glGetUniformLocation(program, name);
+        if (location >= 0) {
+            GL20.glUniform3f(location, x, y, z);
+        }
+    }
+
+    private static void uploadFloat(int program, String name, float value) {
+        int location = GL20.glGetUniformLocation(program, name);
+        if (location >= 0) {
+            GL20.glUniform1f(location, value);
+        }
+    }
+
+    private static void uploadInt(int program, String name, int value) {
+        int location = GL20.glGetUniformLocation(program, name);
+        if (location >= 0) {
+            GL20.glUniform1i(location, value);
         }
     }
 }

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
@@ -13,8 +13,6 @@ public final class IrisShaderTransformer {
     private static final Pattern MAIN_PATTERN = Pattern.compile("void\\s+main\\s*\\(\\s*\\)\\s*\\{");
     private static final Pattern OUT0_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*0\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
     private static final Pattern OUT1_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*1\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
-    private static final String TEXTURE_SAMPLE_PATTERN =
-            "(?m)(?<lhs>\\b%s\\s*=\\s*)(?<sample>texture(?:2D)?\\s*\\([^;]+\\)(?:\\s*\\*\\s*[^;]+)?);";
 
     private IrisShaderTransformer() {
     }
@@ -68,10 +66,9 @@ public final class IrisShaderTransformer {
                     vec3 nebulaFinalViewPos = nebulaViewCenter.xyz + vec3(nebulaCorner, 0.0);
                     NebulaVDistance = length(nebulaViewCenter.xyz);
                     gl_Position = NebulaProjMat * vec4(nebulaFinalViewPos, 1.0);
-                    %s
                     return;
                 }
-            """.formatted(instanceId, buildCompatibilityVertexAssignments(transformed));
+            """.formatted(instanceId);
         return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
     }
 
@@ -96,10 +93,6 @@ public final class IrisShaderTransformer {
             return source;
         }
 
-        String withNebulaSample = replacePrimaryTextureSample(transformed, primaryOutput);
-        boolean usesOriginalPipeline = !withNebulaSample.equals(transformed);
-        transformed = withNebulaSample;
-
         Matcher mainMatcher = MAIN_PATTERN.matcher(transformed);
         if (!mainMatcher.find()) {
             return source;
@@ -108,113 +101,15 @@ public final class IrisShaderTransformer {
         String textureFunction = version >= 130 ? "texture" : "texture2DArray";
         String secondaryOutput = findSecondaryOutput(transformed);
         String secondaryOutputLine = secondaryOutput == null ? "" : secondaryOutput + " = vec4(nebulaAlpha);";
-        String injectedMain = usesOriginalPipeline
-                ? originalPipelineFragmentPrefix(textureFunction)
-                : fallbackFragmentPrefix(textureFunction, primaryOutput, secondaryOutputLine);
+        // Do not continue through the shaderpack's original particle body.  Its
+        // fog/material path consumes pack-specific vertex varyings (and may apply
+        // another alpha discard) which Nebula's instanced vertices intentionally
+        // do not provide.  That made the result depend on the far background,
+        // especially for low-alpha particles at the horizon.
+        String injectedMain = fallbackFragmentPrefix(textureFunction, primaryOutput, secondaryOutputLine);
 
         int bodyStart = mainMatcher.end();
         return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
-    }
-
-    private static String buildCompatibilityVertexAssignments(String source) {
-        StringBuilder assignments = new StringBuilder();
-        appendIfDeclared(assignments, source, "out vec2 uv", "uv = NebulaVUV;");
-        appendIfDeclared(assignments, source, "varying vec2 uv", "uv = NebulaVUV;");
-        appendIfDeclared(assignments, source, "out vec4 tint", "tint = NebulaVColor;");
-        appendIfDeclared(assignments, source, "varying vec4 tint", "tint = NebulaVColor;");
-        appendIfDeclared(assignments, source, "out vec2 light_levels", "light_levels = vec2(1.0);");
-        appendIfDeclared(assignments, source, "varying vec2 light_levels", "light_levels = vec2(1.0);");
-        appendIfDeclared(assignments, source, "out vec3 position_view", "position_view = nebulaFinalViewPos;");
-        appendIfDeclared(assignments, source, "varying vec3 position_view", "position_view = nebulaFinalViewPos;");
-        if (declares(source, "out vec3 position_scene") || declares(source, "varying vec3 position_scene")) {
-            if (source.contains("view_to_scene_space")) {
-                assignments.append("position_scene = view_to_scene_space(nebulaFinalViewPos);\n");
-            } else {
-                assignments.append("position_scene = nebulaFinalViewPos;\n");
-            }
-        }
-        if (declares(source, "flat out uint material_mask")) {
-            assignments.append("material_mask = 0u;\n");
-        } else if (declares(source, "flat out int material_mask") || declares(source, "out int material_mask")) {
-            assignments.append("material_mask = 0;\n");
-        }
-        appendIfDeclared(assignments, source, "flat out mat3 tbn",
-                "tbn = mat3(vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0), vec3(0.0, 0.0, 1.0));");
-        if (source.contains("fog_params") && source.contains("get_fog_parameters") && source.contains("get_weather")) {
-            assignments.append("fog_params = get_fog_parameters(get_weather());\n");
-        }
-        return assignments.toString();
-    }
-
-    private static void appendIfDeclared(StringBuilder builder, String source, String declaration, String assignment) {
-        if (declares(source, declaration)) {
-            builder.append(assignment).append('\n');
-        }
-    }
-
-    private static boolean declares(String source, String declaration) {
-        return source.contains(declaration);
-    }
-
-    private static String replacePrimaryTextureSample(String source, String primaryOutput) {
-        Matcher mainMatcher = MAIN_PATTERN.matcher(source);
-        if (!mainMatcher.find()) {
-            return source;
-        }
-
-        String outputPattern = Pattern.quote(primaryOutput)
-                .replace("\\Qgl_FragData[0]\\E", "gl_FragData\\s*\\[\\s*0\\s*\\]");
-        Pattern pattern = Pattern.compile(TEXTURE_SAMPLE_PATTERN.formatted(outputPattern));
-        String beforeMainBody = source.substring(0, mainMatcher.end());
-        String mainBodyAndRest = source.substring(mainMatcher.end());
-        Matcher matcher = pattern.matcher(mainBodyAndRest);
-        if (!matcher.find()) {
-            return source;
-        }
-
-        String originalAssignment = matcher.group();
-        String replacement = """
-                if (NebulaIsActive == 1) {
-                    %s = nebulaBaseColor;
-                } else {
-                    %s
-                }""".formatted(primaryOutput, originalAssignment);
-        return beforeMainBody + matcher.replaceFirst(Matcher.quoteReplacement(replacement));
-    }
-
-    private static String originalPipelineFragmentPrefix(String textureFunction) {
-        return """
-
-                vec4 nebulaBaseColor = vec4(1.0);
-                if (NebulaIsActive == 1) {
-                    const float nebulaAlphaCutoff = 0.001;
-                    vec4 nebulaTexColor;
-                    if (NebulaUseTexture == 1) {
-                        nebulaTexColor = %s(NebulaSampler0, vec3(NebulaVUV, NebulaVTexLayer));
-                    } else {
-                        vec2 nebulaCenter = NebulaVUV - 0.5;
-                        float nebulaDist = length(nebulaCenter) * 2.0;
-                        float nebulaAlpha = 1.0 - smoothstep(0.5, 1.0, nebulaDist);
-                        float nebulaCoreBrightness = 1.0 + 0.5 * (1.0 - smoothstep(0.0, 0.3, nebulaDist));
-                        nebulaTexColor = vec4(vec3(nebulaCoreBrightness), nebulaAlpha);
-                    }
-                    nebulaBaseColor = nebulaTexColor * NebulaVColor;
-                    nebulaBaseColor.rgb *= NebulaVBloomFactor * NebulaEmissiveStrength;
-                    if (NebulaRenderPass == 0) {
-                        if (nebulaBaseColor.a < 0.5) {
-                            discard;
-                        }
-                    } else if (NebulaRenderPass == 1 || NebulaRenderPass == 3) {
-                        if (nebulaBaseColor.a < nebulaAlphaCutoff || nebulaBaseColor.a >= 0.5) {
-                            discard;
-                        }
-                    } else {
-                        if (nebulaBaseColor.a < nebulaAlphaCutoff) {
-                            discard;
-                        }
-                    }
-                }
-            """.formatted(textureFunction);
     }
 
     private static String fallbackFragmentPrefix(String textureFunction, String primaryOutput, String secondaryOutputLine) {
@@ -260,7 +155,9 @@ public final class IrisShaderTransformer {
                         %s
                     } else {
                         vec3 nebulaHdrColor = nebulaOutputColor * NebulaVBloomFactor * NebulaEmissiveStrength;
-                        %s = vec4(nebulaHdrColor, nebulaBaseColor.a);
+                        // Iris particle targets are composited with premultiplied
+                        // alpha, including their alpha channel.
+                        %s = vec4(nebulaHdrColor * nebulaBaseColor.a, nebulaBaseColor.a);
                     }
                     return;
                 }

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
@@ -1,0 +1,54 @@
+package com.atemukesu.nebula.client.shader;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class IrisShaderTransformer {
+
+    private static final String TOGGLE_UNIFORM = "uniform int NebulaIsActive;";
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(?m)^\\s*#version\\b.*$");
+    private static final String[] TARGET_HINTS = {
+            "gbuffer_textured",
+            "gbuffer_textured_lit",
+            "gbuffer_entities",
+            "gbuffer_entity",
+            "gbuffer_weather",
+            "gbuffer_clouds"
+    };
+
+    private IrisShaderTransformer() {
+    }
+
+    public static String transformVertexSource(String source) {
+        if (source == null || source.isBlank() || source.contains("NebulaIsActive")) {
+            return source;
+        }
+        if (!looksLikeTargetShader(source)) {
+            return source;
+        }
+
+        Matcher versionMatcher = VERSION_PATTERN.matcher(source);
+        if (!versionMatcher.find()) {
+            return TOGGLE_UNIFORM + "\n" + source;
+        }
+
+        int insertAt = versionMatcher.end();
+        return source.substring(0, insertAt) + "\n\n" + TOGGLE_UNIFORM + source.substring(insertAt);
+    }
+
+    private static boolean looksLikeTargetShader(String source) {
+        String normalized = source.toLowerCase(Locale.ROOT);
+        if (normalized.contains("particles[gl_instanceid]") || normalized.contains("layout(std430")) {
+            return false;
+        }
+        for (String hint : TARGET_HINTS) {
+            if (normalized.contains(hint)) {
+                return true;
+            }
+        }
+        return normalized.contains("gl_position")
+                && normalized.contains("sampler2d")
+                && (normalized.contains("texture") || normalized.contains("texcoord"));
+    }
+}

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
@@ -1,54 +1,435 @@
 package com.atemukesu.nebula.client.shader;
 
+import com.atemukesu.nebula.Nebula;
+
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class IrisShaderTransformer {
 
-    private static final String TOGGLE_UNIFORM = "uniform int NebulaIsActive;";
-    private static final Pattern VERSION_PATTERN = Pattern.compile("(?m)^\\s*#version\\b.*$");
-    private static final String[] TARGET_HINTS = {
-            "gbuffer_textured",
-            "gbuffer_textured_lit",
-            "gbuffer_entities",
-            "gbuffer_entity",
-            "gbuffer_weather",
-            "gbuffer_clouds"
-    };
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(?m)^\\s*#version\\s+(\\d+)\\b.*$");
+    private static final Pattern EXTENSION_PATTERN = Pattern.compile("(?m)^\\s*#extension\\b.*$");
+    private static final Pattern MAIN_PATTERN = Pattern.compile("void\\s+main\\s*\\(\\s*\\)\\s*\\{");
+    private static final Pattern OUT0_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*0\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
+    private static final Pattern OUT1_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*1\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
+    private static final String TEXTURE_SAMPLE_PATTERN =
+            "(?m)(?<lhs>\\b%s\\s*=\\s*)(?<sample>texture(?:2D)?\\s*\\([^;]+\\)(?:\\s*\\*\\s*[^;]+)?);";
 
     private IrisShaderTransformer() {
     }
 
-    public static String transformVertexSource(String source) {
-        if (source == null || source.isBlank() || source.contains("NebulaIsActive")) {
-            return source;
-        }
-        if (!looksLikeTargetShader(source)) {
+    public static String transformVertexSource(String programName, String source) {
+        if (!isTargetProgram(programName) || !looksLikeParticleVertexShader(source) || source.contains("NebulaVColor")) {
             return source;
         }
 
-        Matcher versionMatcher = VERSION_PATTERN.matcher(source);
-        if (!versionMatcher.find()) {
-            return TOGGLE_UNIFORM + "\n" + source;
+        int version = shaderVersion(source);
+        if (version < 120) {
+            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} vertex hook because GLSL {} is unsupported.", programName, version);
+            return source;
         }
 
-        int insertAt = versionMatcher.end();
-        return source.substring(0, insertAt) + "\n\n" + TOGGLE_UNIFORM + source.substring(insertAt);
+        String transformed = injectShaderBlock(source, vertexExtensions(version), vertexBlock(version));
+        if (transformed == null) {
+            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} vertex hook because the shader has no #version directive.", programName);
+            return source;
+        }
+
+        Matcher mainMatcher = MAIN_PATTERN.matcher(transformed);
+        if (!mainMatcher.find()) {
+            return source;
+        }
+
+        String instanceId = version >= 140 ? "gl_InstanceID" : "gl_InstanceIDARB";
+        int bodyStart = mainMatcher.end();
+        String injectedMain = """
+
+                if (NebulaIsActive == 1) {
+                    NebulaParticle nebulaParticle = nebulaParticles[%s];
+                    uint nebulaColor = nebulaParticle.colorPacked;
+                    NebulaVColor = vec4(
+                        float(nebulaColor & 255u),
+                        float((nebulaColor >> 8u) & 255u),
+                        float((nebulaColor >> 16u) & 255u),
+                        float((nebulaColor >> 24u) & 255u)
+                    ) / 255.0;
+                    NebulaVTexLayer = nebulaParticle.texLayer;
+                    NebulaVBloomFactor = 1.5;
+                    NebulaVUV = vec2((gl_VertexID == 1 || gl_VertexID == 2) ? 1.0 : 0.0,
+                                     (gl_VertexID <= 1) ? 1.0 : 0.0);
+                    vec3 nebulaPrevPos = vec3(nebulaParticle.prevX, nebulaParticle.prevY, nebulaParticle.prevZ);
+                    vec3 nebulaCurrPos = vec3(nebulaParticle.curX, nebulaParticle.curY, nebulaParticle.curZ);
+                    vec3 nebulaInterpolatedPos = mix(nebulaPrevPos, nebulaCurrPos, NebulaPartialTicks);
+                    vec3 nebulaCenterWorld = NebulaOrigin + nebulaInterpolatedPos;
+                    vec4 nebulaViewCenter = NebulaModelViewMat * vec4(nebulaCenterWorld, 1.0);
+                    vec2 nebulaCorner = vec2((gl_VertexID == 0 || gl_VertexID == 3) ? -0.5 : 0.5,
+                                             (gl_VertexID <= 1) ? -0.5 : 0.5) * nebulaParticle.size;
+                    vec3 nebulaFinalViewPos = nebulaViewCenter.xyz + vec3(nebulaCorner, 0.0);
+                    NebulaVDistance = length(nebulaViewCenter.xyz);
+                    gl_Position = NebulaProjMat * vec4(nebulaFinalViewPos, 1.0);
+                    %s
+                    return;
+                }
+            """.formatted(instanceId, buildCompatibilityVertexAssignments(transformed));
+        return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
     }
 
-    private static boolean looksLikeTargetShader(String source) {
-        String normalized = source.toLowerCase(Locale.ROOT);
-        if (normalized.contains("particles[gl_instanceid]") || normalized.contains("layout(std430")) {
-            return false;
+    public static String transformFragmentSource(String programName, String source) {
+        if (!isTargetProgram(programName) || !looksLikeParticleFragmentShader(source) || source.contains("NebulaVColor")) {
+            return source;
         }
-        for (String hint : TARGET_HINTS) {
-            if (normalized.contains(hint)) {
-                return true;
+
+        int version = shaderVersion(source);
+        if (version < 120) {
+            return source;
+        }
+
+        String primaryOutput = findPrimaryOutput(source);
+        if (primaryOutput == null) {
+            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} fragment hook because no color output was recognized.", programName);
+            return source;
+        }
+
+        String transformed = injectShaderBlock(source, fragmentExtensions(version), fragmentBlock(version));
+        if (transformed == null) {
+            return source;
+        }
+
+        String withNebulaSample = replacePrimaryTextureSample(transformed, primaryOutput);
+        boolean usesOriginalPipeline = !withNebulaSample.equals(transformed);
+        transformed = withNebulaSample;
+
+        Matcher mainMatcher = MAIN_PATTERN.matcher(transformed);
+        if (!mainMatcher.find()) {
+            return source;
+        }
+
+        String textureFunction = version >= 130 ? "texture" : "texture2DArray";
+        String secondaryOutput = findSecondaryOutput(transformed);
+        String secondaryOutputLine = secondaryOutput == null ? "" : secondaryOutput + " = vec4(nebulaAlpha);";
+        String injectedMain = usesOriginalPipeline
+                ? originalPipelineFragmentPrefix(textureFunction)
+                : fallbackFragmentPrefix(textureFunction, primaryOutput, secondaryOutputLine);
+
+        int bodyStart = mainMatcher.end();
+        return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
+    }
+
+    private static String buildCompatibilityVertexAssignments(String source) {
+        StringBuilder assignments = new StringBuilder();
+        appendIfDeclared(assignments, source, "out vec2 uv", "uv = NebulaVUV;");
+        appendIfDeclared(assignments, source, "varying vec2 uv", "uv = NebulaVUV;");
+        appendIfDeclared(assignments, source, "out vec4 tint", "tint = NebulaVColor;");
+        appendIfDeclared(assignments, source, "varying vec4 tint", "tint = NebulaVColor;");
+        appendIfDeclared(assignments, source, "out vec2 light_levels", "light_levels = vec2(1.0);");
+        appendIfDeclared(assignments, source, "varying vec2 light_levels", "light_levels = vec2(1.0);");
+        appendIfDeclared(assignments, source, "out vec3 position_view", "position_view = nebulaFinalViewPos;");
+        appendIfDeclared(assignments, source, "varying vec3 position_view", "position_view = nebulaFinalViewPos;");
+        if (declares(source, "out vec3 position_scene") || declares(source, "varying vec3 position_scene")) {
+            if (source.contains("view_to_scene_space")) {
+                assignments.append("position_scene = view_to_scene_space(nebulaFinalViewPos);\n");
+            } else {
+                assignments.append("position_scene = nebulaFinalViewPos;\n");
             }
         }
-        return normalized.contains("gl_position")
-                && normalized.contains("sampler2d")
-                && (normalized.contains("texture") || normalized.contains("texcoord"));
+        if (declares(source, "flat out uint material_mask")) {
+            assignments.append("material_mask = 0u;\n");
+        } else if (declares(source, "flat out int material_mask") || declares(source, "out int material_mask")) {
+            assignments.append("material_mask = 0;\n");
+        }
+        appendIfDeclared(assignments, source, "flat out mat3 tbn",
+                "tbn = mat3(vec3(1.0, 0.0, 0.0), vec3(0.0, 1.0, 0.0), vec3(0.0, 0.0, 1.0));");
+        if (source.contains("fog_params") && source.contains("get_fog_parameters") && source.contains("get_weather")) {
+            assignments.append("fog_params = get_fog_parameters(get_weather());\n");
+        }
+        return assignments.toString();
+    }
+
+    private static void appendIfDeclared(StringBuilder builder, String source, String declaration, String assignment) {
+        if (declares(source, declaration)) {
+            builder.append(assignment).append('\n');
+        }
+    }
+
+    private static boolean declares(String source, String declaration) {
+        return source.contains(declaration);
+    }
+
+    private static String replacePrimaryTextureSample(String source, String primaryOutput) {
+        Matcher mainMatcher = MAIN_PATTERN.matcher(source);
+        if (!mainMatcher.find()) {
+            return source;
+        }
+
+        String outputPattern = Pattern.quote(primaryOutput)
+                .replace("\\Qgl_FragData[0]\\E", "gl_FragData\\s*\\[\\s*0\\s*\\]");
+        Pattern pattern = Pattern.compile(TEXTURE_SAMPLE_PATTERN.formatted(outputPattern));
+        String beforeMainBody = source.substring(0, mainMatcher.end());
+        String mainBodyAndRest = source.substring(mainMatcher.end());
+        Matcher matcher = pattern.matcher(mainBodyAndRest);
+        if (!matcher.find()) {
+            return source;
+        }
+
+        String originalAssignment = matcher.group();
+        String replacement = """
+                if (NebulaIsActive == 1) {
+                    %s = nebulaBaseColor;
+                } else {
+                    %s
+                }""".formatted(primaryOutput, originalAssignment);
+        return beforeMainBody + matcher.replaceFirst(Matcher.quoteReplacement(replacement));
+    }
+
+    private static String originalPipelineFragmentPrefix(String textureFunction) {
+        return """
+
+                vec4 nebulaBaseColor = vec4(1.0);
+                if (NebulaIsActive == 1) {
+                    const float nebulaAlphaCutoff = 0.001;
+                    vec4 nebulaTexColor;
+                    if (NebulaUseTexture == 1) {
+                        nebulaTexColor = %s(NebulaSampler0, vec3(NebulaVUV, NebulaVTexLayer));
+                    } else {
+                        vec2 nebulaCenter = NebulaVUV - 0.5;
+                        float nebulaDist = length(nebulaCenter) * 2.0;
+                        float nebulaAlpha = 1.0 - smoothstep(0.5, 1.0, nebulaDist);
+                        float nebulaCoreBrightness = 1.0 + 0.5 * (1.0 - smoothstep(0.0, 0.3, nebulaDist));
+                        nebulaTexColor = vec4(vec3(nebulaCoreBrightness), nebulaAlpha);
+                    }
+                    nebulaBaseColor = nebulaTexColor * NebulaVColor;
+                    nebulaBaseColor.rgb *= NebulaVBloomFactor * NebulaEmissiveStrength;
+                    if (NebulaRenderPass == 0) {
+                        if (nebulaBaseColor.a < 0.5) {
+                            discard;
+                        }
+                    } else if (NebulaRenderPass == 1 || NebulaRenderPass == 3) {
+                        if (nebulaBaseColor.a < nebulaAlphaCutoff || nebulaBaseColor.a >= 0.5) {
+                            discard;
+                        }
+                    } else {
+                        if (nebulaBaseColor.a < nebulaAlphaCutoff) {
+                            discard;
+                        }
+                    }
+                }
+            """.formatted(textureFunction);
+    }
+
+    private static String fallbackFragmentPrefix(String textureFunction, String primaryOutput, String secondaryOutputLine) {
+        return """
+                if (NebulaIsActive == 1) {
+                    const float nebulaAlphaCutoff = 0.001;
+                    vec4 nebulaTexColor;
+                    if (NebulaUseTexture == 1) {
+                        nebulaTexColor = %s(NebulaSampler0, vec3(NebulaVUV, NebulaVTexLayer));
+                    } else {
+                        vec2 nebulaCenter = NebulaVUV - 0.5;
+                        float nebulaDist = length(nebulaCenter) * 2.0;
+                        float nebulaAlpha = 1.0 - smoothstep(0.5, 1.0, nebulaDist);
+                        float nebulaCoreBrightness = 1.0 + 0.5 * (1.0 - smoothstep(0.0, 0.3, nebulaDist));
+                        nebulaTexColor = vec4(vec3(nebulaCoreBrightness), nebulaAlpha);
+                    }
+
+                    vec4 nebulaBaseColor = nebulaTexColor * NebulaVColor;
+                    if (NebulaRenderPass == 0) {
+                        if (nebulaBaseColor.a < 0.5) {
+                            discard;
+                        }
+                    } else if (NebulaRenderPass == 1 || NebulaRenderPass == 3) {
+                        if (nebulaBaseColor.a < nebulaAlphaCutoff || nebulaBaseColor.a >= 0.5) {
+                            discard;
+                        }
+                    } else {
+                        if (nebulaBaseColor.a < nebulaAlphaCutoff) {
+                            discard;
+                        }
+                    }
+
+                    vec3 nebulaOutputColor = nebulaBaseColor.rgb;
+                    if (NebulaRenderPass == 1) {
+                        float nebulaAlpha = clamp(nebulaBaseColor.a, 0.0, 1.0);
+                        float nebulaWeight = clamp(
+                            pow(min(1.0, nebulaAlpha * 5.0) + 0.01, 3.0)
+                            * pow(1.0 - gl_FragCoord.z * 0.9, 3.0)
+                            * 250.0,
+                            1e-2, 100.0
+                        );
+                        %s = vec4(nebulaOutputColor * nebulaAlpha * nebulaWeight, nebulaAlpha * nebulaWeight);
+                        %s
+                    } else {
+                        vec3 nebulaHdrColor = nebulaOutputColor * NebulaVBloomFactor * NebulaEmissiveStrength;
+                        %s = vec4(nebulaHdrColor, nebulaBaseColor.a);
+                    }
+                    return;
+                }
+            """.formatted(textureFunction, primaryOutput, secondaryOutputLine, primaryOutput);
+    }
+
+    private static String vertexExtensions(int version) {
+        StringBuilder extensions = new StringBuilder();
+        extensions.append("#extension GL_ARB_shader_storage_buffer_object : require\n");
+        if (version < 140) {
+            extensions.append("#extension GL_ARB_draw_instanced : require\n");
+        }
+        if (version < 130) {
+            extensions.append("#extension GL_EXT_gpu_shader4 : require\n");
+        }
+        return extensions.toString();
+    }
+
+    private static String fragmentExtensions(int version) {
+        if (version < 130) {
+            return "#extension GL_EXT_texture_array : require\n#extension GL_EXT_gpu_shader4 : require\n";
+        }
+        return "";
+    }
+
+    private static String vertexBlock(int version) {
+        String varying = version >= 130 ? "out" : "varying";
+        return """
+                struct NebulaParticle {
+                    float prevX, prevY, prevZ;
+                    float size;
+                    float curX, curY, curZ;
+                    uint colorPacked;
+                    float texLayer;
+                    float pad1, pad2, pad3;
+                };
+
+                layout(std430) buffer NebulaParticleBuffer {
+                    NebulaParticle nebulaParticles[];
+                };
+
+                uniform int NebulaIsActive;
+                uniform mat4 NebulaModelViewMat;
+                uniform mat4 NebulaProjMat;
+                uniform vec3 NebulaOrigin;
+                uniform float NebulaPartialTicks;
+
+                %s vec4 NebulaVColor;
+                %s vec2 NebulaVUV;
+                %s float NebulaVTexLayer;
+                %s float NebulaVDistance;
+                %s float NebulaVBloomFactor;
+                """.formatted(varying, varying, varying, varying, varying);
+    }
+
+    private static String fragmentBlock(int version) {
+        String varying = version >= 130 ? "in" : "varying";
+        return """
+                uniform int NebulaIsActive;
+                uniform sampler2DArray NebulaSampler0;
+                uniform int NebulaUseTexture;
+                uniform float NebulaEmissiveStrength;
+                uniform int NebulaRenderPass;
+
+                %s vec4 NebulaVColor;
+                %s vec2 NebulaVUV;
+                %s float NebulaVTexLayer;
+                %s float NebulaVDistance;
+                %s float NebulaVBloomFactor;
+                """.formatted(varying, varying, varying, varying, varying);
+    }
+
+    private static String injectShaderBlock(String source, String extensions, String block) {
+        Matcher versionMatcher = VERSION_PATTERN.matcher(source);
+        if (!versionMatcher.find()) {
+            return null;
+        }
+
+        int versionEnd = versionMatcher.end();
+        String withExtensions = source.substring(0, versionEnd) + "\n" + extensions + source.substring(versionEnd);
+        Matcher extensionMatcher = EXTENSION_PATTERN.matcher(withExtensions);
+        int declarationsAt = versionEnd + extensions.length() + 1;
+        while (extensionMatcher.find()) {
+            declarationsAt = Math.max(declarationsAt, extensionMatcher.end());
+        }
+        return withExtensions.substring(0, declarationsAt) + "\n" + block + "\n" + withExtensions.substring(declarationsAt);
+    }
+
+    private static int shaderVersion(String source) {
+        Matcher matcher = VERSION_PATTERN.matcher(source);
+        if (!matcher.find()) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(matcher.group(1));
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private static String findPrimaryOutput(String source) {
+        String namedOutput = findOutputName(source, OUT0_PATTERN);
+        if (namedOutput != null) {
+            return namedOutput;
+        }
+        if (source.contains("gl_FragData")) {
+            return "gl_FragData[0]";
+        }
+        if (source.contains("gl_FragColor")) {
+            return "gl_FragColor";
+        }
+        return null;
+    }
+
+    private static String findSecondaryOutput(String source) {
+        String namedOutput = findOutputName(source, OUT1_PATTERN);
+        if (namedOutput != null) {
+            return namedOutput;
+        }
+        if (source.contains("gl_FragData[1]")) {
+            return "gl_FragData[1]";
+        }
+        return null;
+    }
+
+    private static String findOutputName(String source, Pattern pattern) {
+        Matcher matcher = pattern.matcher(source);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static boolean looksLikeParticleVertexShader(String source) {
+        if (source == null || source.isBlank()) {
+            return false;
+        }
+        String normalized = source.toLowerCase(Locale.ROOT);
+        return (normalized.contains("gl_position") || normalized.contains("position"))
+                && (normalized.contains("texcoord") || normalized.contains("uv") || normalized.contains("texture"))
+                && (normalized.contains("color") || normalized.contains("vertexcolor") || normalized.contains("particle"));
+    }
+
+    private static boolean looksLikeParticleFragmentShader(String source) {
+        if (source == null || source.isBlank()) {
+            return false;
+        }
+        String normalized = source.toLowerCase(Locale.ROOT);
+        return (normalized.contains("gl_fragcolor") || normalized.contains("gl_fragdata") || normalized.contains("layout(location"))
+                && (normalized.contains("texture") || normalized.contains("sampler"))
+                && (normalized.contains("alpha") || normalized.contains("discard") || normalized.contains("color"));
+    }
+
+    private static boolean isTargetProgram(String programName) {
+        if (programName == null) {
+            return false;
+        }
+        String normalized = programName.replace('\\', '/').toLowerCase(Locale.ROOT);
+        if (normalized.contains("shadow")) {
+            return false;
+        }
+        int slash = normalized.lastIndexOf('/');
+        if (slash >= 0) {
+            normalized = normalized.substring(slash + 1);
+        }
+        int extension = normalized.indexOf('.');
+        if (extension >= 0) {
+            normalized = normalized.substring(0, extension);
+        }
+        return normalized.contains("particle")
+                || normalized.equals("particles")
+                || normalized.equals("particles_trans")
+                || normalized.equals("shadow_particles");
     }
 }

--- a/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
+++ b/src/main/java/com/atemukesu/nebula/client/shader/IrisShaderTransformer.java
@@ -1,7 +1,12 @@
 package com.atemukesu.nebula.client.shader;
 
 import com.atemukesu.nebula.Nebula;
+import com.atemukesu.nebula.client.config.ModConfig;
+import net.fabricmc.loader.api.FabricLoader;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -12,7 +17,6 @@ public final class IrisShaderTransformer {
     private static final Pattern EXTENSION_PATTERN = Pattern.compile("(?m)^\\s*#extension\\b.*$");
     private static final Pattern MAIN_PATTERN = Pattern.compile("void\\s+main\\s*\\(\\s*\\)\\s*\\{");
     private static final Pattern OUT0_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*0\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
-    private static final Pattern OUT1_PATTERN = Pattern.compile("layout\\s*\\(\\s*location\\s*=\\s*1\\s*\\)\\s*out\\s+vec4\\s+(\\w+)\\s*;");
 
     private IrisShaderTransformer() {
     }
@@ -24,13 +28,11 @@ public final class IrisShaderTransformer {
 
         int version = shaderVersion(source);
         if (version < 120) {
-            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} vertex hook because GLSL {} is unsupported.", programName, version);
             return source;
         }
 
         String transformed = injectShaderBlock(source, vertexExtensions(version), vertexBlock(version));
         if (transformed == null) {
-            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} vertex hook because the shader has no #version directive.", programName);
             return source;
         }
 
@@ -69,7 +71,12 @@ public final class IrisShaderTransformer {
                     return;
                 }
             """.formatted(instanceId);
-        return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
+        String result = transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
+        Nebula.LOGGER.info("[Nebula/Iris] Injected {} vertex: instanceId={}, length={}", programName, instanceId, result.length());
+        if (ModConfig.getInstance().getSaveInjectedCode()) {
+            saveInjectedCode(programName, "vert", result);
+        }
+        return result;
     }
 
     public static String transformFragmentSource(String programName, String source) {
@@ -78,20 +85,18 @@ public final class IrisShaderTransformer {
         }
 
         int version = shaderVersion(source);
-        if (version < 120) {
-            return source;
-        }
+        if (version < 120) return source;
 
         String primaryOutput = findPrimaryOutput(source);
         if (primaryOutput == null) {
-            Nebula.LOGGER.warn("[Nebula/Iris] Skipping {} fragment hook because no color output was recognized.", programName);
             return source;
         }
 
+        boolean hasOutput3 = hasOutputVariable(source, "gbufferOutput3");
+        boolean hasOutput5 = hasOutputVariable(source, "gbufferOutput5");
+
         String transformed = injectShaderBlock(source, fragmentExtensions(version), fragmentBlock(version));
-        if (transformed == null) {
-            return source;
-        }
+        if (transformed == null) return source;
 
         Matcher mainMatcher = MAIN_PATTERN.matcher(transformed);
         if (!mainMatcher.find()) {
@@ -99,69 +104,84 @@ public final class IrisShaderTransformer {
         }
 
         String textureFunction = version >= 130 ? "texture" : "texture2DArray";
-        String secondaryOutput = findSecondaryOutput(transformed);
-        String secondaryOutputLine = secondaryOutput == null ? "" : secondaryOutput + " = vec4(nebulaAlpha);";
-        // Do not continue through the shaderpack's original particle body.  Its
-        // fog/material path consumes pack-specific vertex varyings (and may apply
-        // another alpha discard) which Nebula's instanced vertices intentionally
-        // do not provide.  That made the result depend on the far background,
-        // especially for low-alpha particles at the horizon.
-        String injectedMain = fallbackFragmentPrefix(textureFunction, primaryOutput, secondaryOutputLine);
+
+        String injectedMain = buildDynamicFragmentBody(
+                primaryOutput,
+                textureFunction,
+                hasOutput3,
+                hasOutput5
+        );
 
         int bodyStart = mainMatcher.end();
-        return transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
+        String result = transformed.substring(0, bodyStart) + injectedMain + transformed.substring(bodyStart);
+        Nebula.LOGGER.info("[Nebula/Iris] Injected {} fragment: primary={}, hasOut3={}, hasOut5={}, length={}",
+                programName, primaryOutput, hasOutput3, hasOutput5, result.length());
+        if (ModConfig.getInstance().getSaveInjectedCode()) {
+            saveInjectedCode(programName, "frag", result);
+        }
+        return result;
     }
 
-    private static String fallbackFragmentPrefix(String textureFunction, String primaryOutput, String secondaryOutputLine) {
-        return """
-                if (NebulaIsActive == 1) {
-                    const float nebulaAlphaCutoff = 0.001;
-                    vec4 nebulaTexColor;
-                    if (NebulaUseTexture == 1) {
-                        nebulaTexColor = %s(NebulaSampler0, vec3(NebulaVUV, NebulaVTexLayer));
-                    } else {
-                        vec2 nebulaCenter = NebulaVUV - 0.5;
-                        float nebulaDist = length(nebulaCenter) * 2.0;
-                        float nebulaAlpha = 1.0 - smoothstep(0.5, 1.0, nebulaDist);
-                        float nebulaCoreBrightness = 1.0 + 0.5 * (1.0 - smoothstep(0.0, 0.3, nebulaDist));
-                        nebulaTexColor = vec4(vec3(nebulaCoreBrightness), nebulaAlpha);
-                    }
+    private static String buildDynamicFragmentBody(String primaryOutput, String textureFunction,
+                                                   boolean hasOut3, boolean hasOut5) {
+        StringBuilder body = new StringBuilder();
+        body.append("if (NebulaIsActive == 1) {\n");
+        body.append("    const float nebulaAlphaCutoff = 0.001;\n");
+        body.append("    vec4 nebulaTexColor;\n");
+        body.append("    if (NebulaUseTexture == 1) {\n");
+        body.append("        nebulaTexColor = ").append(textureFunction).append("(NebulaSampler0, vec3(NebulaVUV, NebulaVTexLayer));\n");
+        body.append("    } else {\n");
+        body.append("        vec2 nebulaCenter = NebulaVUV - 0.5;\n");
+        body.append("        float nebulaDist = length(nebulaCenter) * 2.0;\n");
+        body.append("        float nebulaAlpha = 1.0 - smoothstep(0.5, 1.0, nebulaDist);\n");
+        body.append("        float nebulaCoreBrightness = 1.0 + 0.5 * (1.0 - smoothstep(0.0, 0.3, nebulaDist));\n");
+        body.append("        nebulaTexColor = vec4(vec3(nebulaCoreBrightness), nebulaAlpha);\n");
+        body.append("    }\n");
+        body.append("    vec4 nebulaBaseColor = nebulaTexColor * NebulaVColor;\n");
 
-                    vec4 nebulaBaseColor = nebulaTexColor * NebulaVColor;
-                    if (NebulaRenderPass == 0) {
-                        if (nebulaBaseColor.a < 0.5) {
-                            discard;
-                        }
-                    } else if (NebulaRenderPass == 1 || NebulaRenderPass == 3) {
-                        if (nebulaBaseColor.a < nebulaAlphaCutoff || nebulaBaseColor.a >= 0.5) {
-                            discard;
-                        }
-                    } else {
-                        if (nebulaBaseColor.a < nebulaAlphaCutoff) {
-                            discard;
-                        }
-                    }
+        body.append("    if (NebulaRenderPass == 0) {\n");
+        body.append("        if (nebulaBaseColor.a < 0.5) discard;\n");
+        body.append("    } else if (NebulaRenderPass == 1 || NebulaRenderPass == 3) {\n");
+        body.append("        if (nebulaBaseColor.a < nebulaAlphaCutoff || nebulaBaseColor.a >= 0.5) discard;\n");
+        body.append("    } else {\n");
+        body.append("        if (nebulaBaseColor.a < nebulaAlphaCutoff) discard;\n");
+        body.append("    }\n");
 
-                    vec3 nebulaOutputColor = nebulaBaseColor.rgb;
-                    if (NebulaRenderPass == 1) {
-                        float nebulaAlpha = clamp(nebulaBaseColor.a, 0.0, 1.0);
-                        float nebulaWeight = clamp(
-                            pow(min(1.0, nebulaAlpha * 5.0) + 0.01, 3.0)
-                            * pow(1.0 - gl_FragCoord.z * 0.9, 3.0)
-                            * 250.0,
-                            1e-2, 100.0
-                        );
-                        %s = vec4(nebulaOutputColor * nebulaAlpha * nebulaWeight, nebulaAlpha * nebulaWeight);
-                        %s
-                    } else {
-                        vec3 nebulaHdrColor = nebulaOutputColor * NebulaVBloomFactor * NebulaEmissiveStrength;
-                        // Iris particle targets are composited with premultiplied
-                        // alpha, including their alpha channel.
-                        %s = vec4(nebulaHdrColor * nebulaBaseColor.a, nebulaBaseColor.a);
-                    }
-                    return;
-                }
-            """.formatted(textureFunction, primaryOutput, secondaryOutputLine, primaryOutput);
+        body.append("    vec3 nebulaOutputColor = nebulaBaseColor.rgb;\n");
+
+        // Pure native GLSL: encode view-space normal (sprite always faces camera)
+        body.append("    vec2 nebulaNormalEnc = vec2(0.5, 0.5);\n");
+        // Pack2x8(vec2(0.0, 1.0)) = 1.0 / 65535.0
+        body.append("    float nebulaPackDefault = 1.0 / 65535.0;\n");
+
+        // Pass 1 (OIT Accumulation)
+        body.append("    if (NebulaRenderPass == 1) {\n");
+        body.append("        float nebulaAlpha = clamp(nebulaBaseColor.a, 0.0, 1.0);\n");
+        body.append("        float nebulaWeight = clamp(pow(min(1.0, nebulaAlpha * 5.0) + 0.01, 3.0) * pow(1.0 - gl_FragCoord.z * 0.9, 3.0) * 250.0, 1e-2, 100.0);\n");
+        body.append("        ").append(primaryOutput).append(" = vec4(nebulaOutputColor * nebulaAlpha * nebulaWeight, nebulaAlpha * nebulaWeight);\n");
+        if (hasOut3) {
+            body.append("        gbufferOutput3 = vec4(nebulaNormalEnc, 1.0, 1.0);\n");
+        }
+        if (hasOut5) {
+            body.append("        gbufferOutput5 = vec4(0.0, 0.0, 40.0 / 255.0, nebulaPackDefault);\n");
+        }
+
+        // Other Passes (0, 2, 3)
+        body.append("    } else {\n");
+        body.append("        vec3 nebulaHdrColor = nebulaOutputColor * NebulaVBloomFactor * NebulaEmissiveStrength;\n");
+        body.append("        ").append(primaryOutput).append(" = vec4(nebulaHdrColor * nebulaBaseColor.a, nebulaBaseColor.a);\n");
+        if (hasOut3) {
+            body.append("        gbufferOutput3 = vec4(nebulaNormalEnc, 1.0, 1.0);\n");
+        }
+        if (hasOut5) {
+            body.append("        gbufferOutput5 = vec4(0.0, 0.0, 40.0 / 255.0, nebulaPackDefault);\n");
+        }
+
+        body.append("    }\n");
+        body.append("    return;\n");
+        body.append("}\n");
+
+        return body.toString();
     }
 
     private static String vertexExtensions(int version) {
@@ -272,20 +292,14 @@ public final class IrisShaderTransformer {
         return null;
     }
 
-    private static String findSecondaryOutput(String source) {
-        String namedOutput = findOutputName(source, OUT1_PATTERN);
-        if (namedOutput != null) {
-            return namedOutput;
-        }
-        if (source.contains("gl_FragData[1]")) {
-            return "gl_FragData[1]";
-        }
-        return null;
-    }
-
     private static String findOutputName(String source, Pattern pattern) {
         Matcher matcher = pattern.matcher(source);
         return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private static boolean hasOutputVariable(String source, String varName) {
+        Pattern p = Pattern.compile("(?:layout\\s*\\(\\s*location\\s*=\\s*\\d+\\s*\\)\\s*)?out\\s+vec4\\s+" + varName + "\\s*;");
+        return p.matcher(source).find();
     }
 
     private static boolean looksLikeParticleVertexShader(String source) {
@@ -328,5 +342,26 @@ public final class IrisShaderTransformer {
                 || normalized.equals("particles")
                 || normalized.equals("particles_trans")
                 || normalized.equals("shadow_particles");
+    }
+
+    private static void saveInjectedCode(String programName, String ext, String code) {
+        try {
+            String safeName = programName.replace('\\', '/').replaceAll("[^a-zA-Z0-9._/\\-]", "_");
+            int lastSlash = safeName.lastIndexOf('/');
+            if (lastSlash >= 0) {
+                safeName = safeName.substring(lastSlash + 1);
+            }
+            int dotIdx = safeName.lastIndexOf('.');
+            if (dotIdx >= 0) {
+                safeName = safeName.substring(0, dotIdx);
+            }
+            Path dir = FabricLoader.getInstance().getGameDir().resolve("nebula").resolve("injected_code");
+            Files.createDirectories(dir);
+            Path file = dir.resolve(safeName + "." + ext);
+            Files.writeString(file, code);
+            Nebula.LOGGER.info("[Nebula/Iris] Saved injected shader code to {}", file);
+        } catch (IOException e) {
+            Nebula.LOGGER.warn("[Nebula/Iris] Failed to save injected shader code for {}: {}", programName, e.getMessage());
+        }
     }
 }

--- a/src/main/resources/assets/nebula/lang/en_us.json
+++ b/src/main/resources/assets/nebula/lang/en_us.json
@@ -59,7 +59,7 @@
     "gui.nebula.config.blend_mode.alpha": "Alpha Blend",
     "gui.nebula.config.blend_mode.oit": "OIT (Order Independent)",
     "gui.nebula.config.blend_mode.depth_priority": "Depth Priority (Iris)",
-    "gui.nebula.config.blend_mode.depth_priority.desc": "Alpha, Additive, and OIT are unavailable while a shaderpack is active.\n\nNebula writes transparent-particle depth before color to prevent later shaderpack layers from clipping particles at the horizon.\n\nTrade-off: nearer transparent particles occlude farther transparent particles.",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "Alpha, Additive, and OIT are unavailable while a shaderpack is active.\n\nNebula writes transparent-particle depth before color to prevent later shaderpack layers from clipping particles at the horizon.\n\nTrade-off: nearer transparent particles occlude farther transparent particles.\n\nIf this significantly affects your experience, please switch the render pipeline to the vanilla pipeline.",
     "gui.nebula.config.culling_behavior": "Particle Culling Behavior",
     "gui.nebula.config.culling_behavior.desc": "Sets how particles are handled when outside the field of view.\n\n§6Skip Rendering Only (Recommended)§r: Keeps logic calculations. No delay when entering view, but consumes CPU.\n\n§6Fully Pause§r: Completely stops processing. §cWarning§r: May cause noticeable stuttering when entering view due to data addressing.",
     "gui.nebula.config.culling_behavior.simulate_only": "Skip Rendering Only",
@@ -68,6 +68,8 @@
     "gui.nebula.config.emissive_strength.desc": "Controls the emissive strength of particles. Higher values make particles glow brighter.",
     "gui.nebula.config.sync_singleplayer": "Singleplayer Animation Sync",
     "gui.nebula.config.sync_singleplayer.desc": "Test option, not recommended to enable.\n\nPerform animation file synchronization checks even in singleplayer games. Normally singleplayer mode doesn't need synchronization since client and server use the same files.",
+    "gui.nebula.config.save_injected_code": "Save Injected Shader Code",
+    "gui.nebula.config.save_injected_code.desc": "Save the transformed shader code after Nebula's injection to the game directory (nebula/injected_code/).\n\nUseful for debugging shader compatibility issues with Iris shader packs.",
     "command.nebula.client.reload.success": "Animations reloaded successfully!",
     "command.nebula.client.reload.failed": "Failed to reload animations. See log for details."
 }

--- a/src/main/resources/assets/nebula/lang/en_us.json
+++ b/src/main/resources/assets/nebula/lang/en_us.json
@@ -58,6 +58,8 @@
     "gui.nebula.config.blend_mode.additive": "Additive Blend",
     "gui.nebula.config.blend_mode.alpha": "Alpha Blend",
     "gui.nebula.config.blend_mode.oit": "OIT (Order Independent)",
+    "gui.nebula.config.blend_mode.depth_priority": "Depth Priority (Iris)",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "Alpha, Additive, and OIT are unavailable while a shaderpack is active.\n\nNebula writes transparent-particle depth before color to prevent later shaderpack layers from clipping particles at the horizon.\n\nTrade-off: nearer transparent particles occlude farther transparent particles.",
     "gui.nebula.config.culling_behavior": "Particle Culling Behavior",
     "gui.nebula.config.culling_behavior.desc": "Sets how particles are handled when outside the field of view.\n\n§6Skip Rendering Only (Recommended)§r: Keeps logic calculations. No delay when entering view, but consumes CPU.\n\n§6Fully Pause§r: Completely stops processing. §cWarning§r: May cause noticeable stuttering when entering view due to data addressing.",
     "gui.nebula.config.culling_behavior.simulate_only": "Skip Rendering Only",

--- a/src/main/resources/assets/nebula/lang/ja_jp.json
+++ b/src/main/resources/assets/nebula/lang/ja_jp.json
@@ -58,6 +58,8 @@
     "gui.nebula.config.blend_mode.additive": "加算ブレンド",
     "gui.nebula.config.blend_mode.alpha": "アルファブレンド",
     "gui.nebula.config.blend_mode.oit": "OIT (順序非依存)",
+    "gui.nebula.config.blend_mode.depth_priority": "深度優先（Iris）",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "シェーダーパック有効中は、アルファ・加算・OIT を使用できません。\n\nNebula は地平線付近で後続のシェーダーパック層に粒子が隠されないよう、色の前に半透明粒子の深度を書き込みます。\n\n代償：手前の半透明粒子が奥の半透明粒子を隠します。",
     "gui.nebula.config.culling_behavior": "パーティクルのカリング挙動",
     "gui.nebula.config.culling_behavior.desc": "視界外にあるパーティクルの処理方法を設定します。\n\n§6描画のみスキップ (推奨)§r: ロジックの計算は維持されます。視界に入った際の遅延はありませんが、CPUを消費します。\n\n§6完全に一時停止§r: すべての処理を停止します。§c警告§r: 視界に入った際、データのアドレッシングによりカクつきが発生する場合があります。",
     "gui.nebula.config.culling_behavior.simulate_only": "描画のみスキップ",

--- a/src/main/resources/assets/nebula/lang/ja_jp.json
+++ b/src/main/resources/assets/nebula/lang/ja_jp.json
@@ -59,7 +59,7 @@
     "gui.nebula.config.blend_mode.alpha": "アルファブレンド",
     "gui.nebula.config.blend_mode.oit": "OIT (順序非依存)",
     "gui.nebula.config.blend_mode.depth_priority": "深度優先（Iris）",
-    "gui.nebula.config.blend_mode.depth_priority.desc": "シェーダーパック有効中は、アルファ・加算・OIT を使用できません。\n\nNebula は地平線付近で後続のシェーダーパック層に粒子が隠されないよう、色の前に半透明粒子の深度を書き込みます。\n\n代償：手前の半透明粒子が奥の半透明粒子を隠します。",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "シェーダーパック有効中は、アルファ・加算・OIT を使用できません。\n\nNebula は地平線付近で後続のシェーダーパック層に粒子が隠されないよう、色の前に半透明粒子の深度を書き込みます。\n\n代償：手前の半透明粒子が奥の半透明粒子を隠します。\n\n使用に支障がある場合は、レンダリングパイプラインをバニラパイプラインに変更してください。",
     "gui.nebula.config.culling_behavior": "パーティクルのカリング挙動",
     "gui.nebula.config.culling_behavior.desc": "視界外にあるパーティクルの処理方法を設定します。\n\n§6描画のみスキップ (推奨)§r: ロジックの計算は維持されます。視界に入った際の遅延はありませんが、CPUを消費します。\n\n§6完全に一時停止§r: すべての処理を停止します。§c警告§r: 視界に入った際、データのアドレッシングによりカクつきが発生する場合があります。",
     "gui.nebula.config.culling_behavior.simulate_only": "描画のみスキップ",
@@ -68,6 +68,8 @@
     "gui.nebula.config.emissive_strength.desc": "パーティクルのエミッシブ強度を制御します。値が高いほどパーティクルがより輝くようになります。",
     "gui.nebula.config.sync_singleplayer": "シングルプレイ アニメーション同期",
     "gui.nebula.config.sync_singleplayer.desc": "テスト用オプション、有効化は推奨されません。\n\nシングルプレイゲームでもアニメーションファイルの同期チェックを行います。通常、シングルプレイモードではクライアントとサーバーが同じファイルを使用するため、同期は必要ありません。",
+    "gui.nebula.config.save_injected_code": "注入済みシェーダーコードを保存",
+    "gui.nebula.config.save_injected_code.desc": "Nebula の注入後の変換済みシェーダーコードをゲームディレクトリ (nebula/injected_code/) に保存します。\n\nIris シェーダーパックとのシェーダー互換性をデバッグする際に便利です。",
     "command.nebula.client.reload.success": "アニメーションが正常に再読み込みされました！",
     "command.nebula.client.reload.failed": "アニメーションの再読み込みに失敗しました。詳細はログを確認してください。"
 }

--- a/src/main/resources/assets/nebula/lang/zh_cn.json
+++ b/src/main/resources/assets/nebula/lang/zh_cn.json
@@ -59,7 +59,7 @@
     "gui.nebula.config.blend_mode.alpha": "标准混合",
     "gui.nebula.config.blend_mode.oit": "OIT (与顺序无关透明度)",
     "gui.nebula.config.blend_mode.depth_priority": "深度优先（Iris）",
-    "gui.nebula.config.blend_mode.depth_priority.desc": "启用光影时，Alpha、加法混合和 OIT 均不可用。\n\nNebula 会先写入半透明粒子的深度，再绘制颜色，以避免粒子在地平线处被后续光影层覆盖。\n\n代价：近处半透明粒子会遮挡远处半透明粒子。",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "启用光影时，Alpha、加法混合和 OIT 均不可用。\n\nNebula 会先写入半透明粒子的深度，再绘制颜色，以避免粒子在地平线处被后续光影层覆盖。\n\n代价：近处半透明粒子会遮挡远处半透明粒子。\n\n如果的确影响使用，请调整渲染管线为原版管线。",
     "gui.nebula.config.culling_behavior": "粒子剔除行为",
     "gui.nebula.config.culling_behavior.desc": "设置粒子在视野外的处理方式。\n\n§6仅跳过渲染（推荐）§r：保持逻辑计算，进入视野无延迟，但消耗CPU。\n\n§6完全暂停§r：完全停止处理。§c警告§r：进入视野时因数据寻址可能产生可感卡顿。",
     "gui.nebula.config.culling_behavior.simulate_only": "仅跳过渲染",
@@ -68,6 +68,8 @@
     "gui.nebula.config.emissive_strength.desc": "控制粒子的发光强度。值越高，粒子越亮。",
     "gui.nebula.config.sync_singleplayer": "单人模式动画同步",
     "gui.nebula.config.sync_singleplayer.desc": "测试用选项，不建议开启。\n\n在单人游戏中也进行动画文件同步检查。通常情况下单人模式不需要同步，因为客户端和服务端使用相同的文件。",
+    "gui.nebula.config.save_injected_code": "保存注入后的着色器代码",
+    "gui.nebula.config.save_injected_code.desc": "将 Nebula 注入后的着色器代码保存到游戏目录 (nebula/injected_code/)。\n\n用于调试 Iris 光影包的着色器兼容性问题。",
     "command.nebula.client.reload.success": "动画重载成功！",
     "command.nebula.client.reload.failed": "动画重载失败。详情请查看日志。"
 }

--- a/src/main/resources/assets/nebula/lang/zh_cn.json
+++ b/src/main/resources/assets/nebula/lang/zh_cn.json
@@ -58,6 +58,8 @@
     "gui.nebula.config.blend_mode.additive": "加法混合",
     "gui.nebula.config.blend_mode.alpha": "标准混合",
     "gui.nebula.config.blend_mode.oit": "OIT (与顺序无关透明度)",
+    "gui.nebula.config.blend_mode.depth_priority": "深度优先（Iris）",
+    "gui.nebula.config.blend_mode.depth_priority.desc": "启用光影时，Alpha、加法混合和 OIT 均不可用。\n\nNebula 会先写入半透明粒子的深度，再绘制颜色，以避免粒子在地平线处被后续光影层覆盖。\n\n代价：近处半透明粒子会遮挡远处半透明粒子。",
     "gui.nebula.config.culling_behavior": "粒子剔除行为",
     "gui.nebula.config.culling_behavior.desc": "设置粒子在视野外的处理方式。\n\n§6仅跳过渲染（推荐）§r：保持逻辑计算，进入视野无延迟，但消耗CPU。\n\n§6完全暂停§r：完全停止处理。§c警告§r：进入视野时因数据寻址可能产生可感卡顿。",
     "gui.nebula.config.culling_behavior.simulate_only": "仅跳过渲染",

--- a/src/main/resources/assets/nebula/shaders/nebula_particle.vsh
+++ b/src/main/resources/assets/nebula/shaders/nebula_particle.vsh
@@ -14,7 +14,7 @@ struct Particle {
     float pad1, pad2, pad3;
 };
 
-layout(std430, binding = 0) buffer ParticleBuffer {
+layout(std430, binding = 12) buffer ParticleBuffer {
     Particle particles[];
 };
 

--- a/src/main/resources/nebula.client.mixins.json
+++ b/src/main/resources/nebula.client.mixins.json
@@ -7,6 +7,7 @@
 		"ParticleManagerAccessor",
 		"VideoRendererMixin",
 		"NebulaWorldRendererMixin",
+		"NebulaParticleManagerMixin",
 		"MixinTransformPatcher"
 	],
 	"injectors": {

--- a/src/main/resources/nebula.client.mixins.json
+++ b/src/main/resources/nebula.client.mixins.json
@@ -7,7 +7,6 @@
 		"ParticleManagerAccessor",
 		"VideoRendererMixin",
 		"NebulaWorldRendererMixin",
-		"NebulaParticleManagerMixin",
 		"MixinTransformPatcher"
 	],
 	"injectors": {

--- a/src/main/resources/nebula.client.mixins.json
+++ b/src/main/resources/nebula.client.mixins.json
@@ -6,7 +6,8 @@
 		"ExampleClientMixin",
 		"ParticleManagerAccessor",
 		"VideoRendererMixin",
-		"NebulaWorldRendererMixin"
+		"NebulaWorldRendererMixin",
+		"MixinTransformPatcher"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
## Summary by Sourcery

集成用于 GPU 粒子渲染的软 Iris 着色器挂钩，将 Nebula 粒子通过 Iris 粒子程序和帧缓冲进行路由，同时保持深度/混合约定，并添加相应配置与工具更新以支持该渲染路径。

New Features:
- 引入 Iris 着色器转换与开关工具，在运行时向 Iris 粒子着色器注入 Nebula 粒子支持。
- 添加新的配置选项和 UI 开关，用于保存注入后的 Iris 着色器代码以便调试。
- 新增 Iris 感知的混合模式处理，在 GPU 粒子运行于着色器包下时强制采用深度优先渲染路径。

Bug Fixes:
- 确保 GPU 粒子在通过 Iris 半透明帧缓冲渲染时遵守深度和混合规则，防止地平线伪影与 alpha 覆写问题。
- 修复在由外部 Iris 程序驱动时的 GPU 粒子 OIT 和标准批量渲染，包括正确的 SSBO 绑定和纹理单元设置。
- 在 Iris 驱动的粒子渲染过程后恢复帧缓冲、视口和 GL 状态，避免破坏后续渲染。
- 在 SSBO 更新后添加内存屏障，确保 PMB 和回退上传对 GPU 可见。

Enhancements:
- 优化 GPU 粒子渲染路径，以便在需要时复用外部着色器程序，并记录活动程序和批次以用于诊断。
- 调整调试 HUD 和配置 UI，使其反映在 Iris 下实际生效的混合模式，并明确深度优先行为。
- 收紧针对可选 Iris/Replay 集成的 mixin 应用逻辑与日志，并将 Iris 粒子渲染移动到半透明地形之后，以获得更佳的合成效果。

Build:
- 构建过程要求使用 JDK 21，并在检测到旧版 JVM 时快速失败。

Chores:
- 将模组版本从 1.0.8 提升到 1.1.0，并更新多处日志消息，以便提供更清晰的 Iris 相关诊断信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a soft Iris shader hook for GPU particle rendering, routing Nebula particles through Iris particle programs and framebuffers while preserving depth/blend contracts, and add configuration and tooling updates to support this path.

New Features:
- Introduce Iris shader transformation and toggling utilities to inject Nebula particle support into Iris particle shaders at runtime.
- Add a new config option and UI toggle to save injected Iris shader code for debugging.
- Add an Iris-aware blend mode handling that forces a depth-priority path when GPU particles run under shaderpacks.

Bug Fixes:
- Ensure GPU particles respect depth and blending when rendered through Iris translucent framebuffers, preventing horizon artifacts and alpha overwrites.
- Fix GPU particle OIT and standard batch rendering when driven by external Iris programs, including correct SSBO bindings and texture units.
- Restore framebuffers, viewports, and GL state after Iris-driven particle passes to avoid corrupting subsequent rendering.
- Add memory barriers after SSBO updates so PMB and fallback uploads are visible to the GPU.

Enhancements:
- Refine GPU particle rendering paths to optionally reuse external shader programs, logging active programs and batches for diagnostics.
- Adjust debug HUD and config UI to reflect the effective blend mode under Iris and clarify depth-priority behavior.
- Tighten mixin application logic and logging for optional Iris/Replay integrations and move Iris particle rendering to occur after translucent terrain for better compositing.

Build:
- Require JDK 21 for the build and fail fast on older JVMs.

Chores:
- Bump the mod version from 1.0.8 to 1.1.0 and update various log messages for clearer Iris-related diagnostics.

</details>